### PR TITLE
EFSM -> Rust monitor with refinements

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -94,6 +94,7 @@ type local_action_verb =
   | GencodeGo
   | GencodeOcaml
   | GencodeOcamlMonadic
+  | GencodeRust
 
 type global_action = global_action_verb * string (* protocol *)
 
@@ -181,6 +182,9 @@ let main args global_actions local_actions =
               |> print_endline
           | GencodeOcamlMonadic ->
               Nuscrlib.generate_ocaml_code ~monad:true ast ~protocol ~role
+              |> print_endline 
+          | GencodeRust -> 
+              Nuscrlib.generate_rust_monitor_code ast ~protocol ~role
               |> print_endline )
         local_actions
     in
@@ -303,8 +307,17 @@ let gencode_go =
     value & opt_all role_proto []
     & info ["gencode-go"] ~doc ~docv:"ROLE@PROTO" )
 
+let gencode_rust =
+  let doc =
+    "Generate Rust code for specified protocol and role. \
+     <role_name>@<protocol_name>"
+  in
+  Arg.(
+    value & opt_all role_proto []
+    & info ["gencode-rust"] ~doc ~docv:"ROLE@PROTO" )
+
 let mk_local_actions project project_mpstk project_tex project_protobuf fsm
-    gencode_fstar gencode_go gencode_ocaml gencode_ocaml_monadic =
+    gencode_fstar gencode_go gencode_ocaml gencode_ocaml_monadic gencode_rust =
   let project = List.map ~f:(fun (r, p) -> (Project, r, p)) project in
   let project_mpstk =
     List.map ~f:(fun (r, p) -> (ProjectMpstk, r, p)) project_mpstk
@@ -330,6 +343,11 @@ let mk_local_actions project project_mpstk project_tex project_protobuf fsm
       ~f:(fun (r, p) -> (GencodeOcamlMonadic, r, p))
       gencode_ocaml_monadic
   in
+  let gencode_rust = 
+    List.map
+      ~f:(fun (r,p) -> (GencodeRust, r, p))
+      gencode_rust
+  in
   List.concat
     [ project
     ; project_mpstk
@@ -339,7 +357,8 @@ let mk_local_actions project project_mpstk project_tex project_protobuf fsm
     ; gencode_fstar
     ; gencode_go
     ; gencode_ocaml
-    ; gencode_ocaml_monadic ]
+    ; gencode_ocaml_monadic
+    ; gencode_rust ]
 
 let sexp_global_type =
   let doc =
@@ -437,7 +456,7 @@ let cmd =
     Term.(
       const mk_local_actions $ project $ project_mpstk $ project_tex
       $ project_protobuf $ fsm $ gencode_fstar $ gencode_go $ gencode_ocaml
-      $ gencode_monadic_ocaml )
+      $ gencode_monadic_ocaml $ gencode_rust )
   in
   let term =
     Term.(ret (const main $ args $ global_actions $ local_actions))

--- a/lib/codegen/codegen.ml
+++ b/lib/codegen/codegen.ml
@@ -1,3 +1,4 @@
 module Fstar = Fstarcodegen
 module Go = Gocodegen
 module Ocaml = Ocamlcodegen
+module Rust = Rustcodegen

--- a/lib/codegen/codegen.mli
+++ b/lib/codegen/codegen.mli
@@ -1,3 +1,4 @@
 module Fstar = Fstarcodegen
 module Go = Gocodegen
 module Ocaml = Ocamlcodegen
+module Rust = Rustcodegen

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -129,24 +129,45 @@ let generate_monitor buffer protocol_name =
         }\n" protocol_name)
 
 
-let generate_transitions buffer start g protocol_name start_rec_vars =
+let generate_constructor buffer start var_map rec_var_info =
+  let start_vars = Map.find_exn var_map start in
+  let start_rv_info =
+    Option.value ~default:[] (Map.find rec_var_info start)
+  in
+  List.iter start_vars ~f:(fun (v, _) ->
+    let is_rec_var =
+      List.exists start_rv_info
+        ~f:(fun (_, rv) -> VariableName.equal v rv.rv_name)
+    in
+    if not is_rec_var then
+      Err.violationf ~here:[%here]
+        "Payload variable '%s' at start state has no initial value"
+        (VariableName.user v));
+  Buffer.add_string buffer "    pub fn new() -> Self {\n";
+  (match start_vars with
+   | [] ->
+       Buffer.add_string buffer
+         (Printf.sprintf "        Self { state: State::S%d }\n" start)
+   | _ ->
+       let inits =
+         List.map start_vars ~f:(fun (v, _) ->
+           let (_, rv) = List.find_exn start_rv_info
+             ~f:(fun (_, rv) -> VariableName.equal v rv.rv_name)
+           in
+           Printf.sprintf "%s: %s"
+             (VariableName.user v)
+             (Rustexpr.rust_show_expr rv.rv_init_expr))
+       in
+       Buffer.add_string buffer
+         (Printf.sprintf "        Self { state: State::S%d { %s } }\n"
+            start (String.concat ~sep:", " inits)));
+  Buffer.add_string buffer "    }\n"
+
+let generate_step_fn buffer g =
   Buffer.add_string buffer
-  ("impl " ^ protocol_name ^ "Monitor {\n\
-  \    pub fn new() -> Self {\n\
-  \        Self {\n\
-  \            state: State::S" ^ (Int.to_string start) ^ ",\n");
-  List.iter start_rec_vars ~f:(fun rv ->
-    Buffer.add_string buffer
-      (Printf.sprintf "            %s: %s,\n"
-         (VariableName.user rv.rv_name)
-         (Rustexpr.rust_show_expr rv.rv_init_expr)));
-  Buffer.add_string buffer
-  ("        }\n\
-  \    }\n\
-  \n\
-  \    pub fn step(&mut self, action: &Action) -> bool {\n\
-  \        match (self.state, action.dir, action.label) {\n\
-  ");
+    "\n\
+    \    pub fn step(&mut self, action: &Action) -> bool {\n\
+    \        match (self.state, action.dir, action.label) {\n";
   G.iter_edges_e (fun (src, a, dst) ->
     match a with
     | SendA (_, m, _) | RecvA (_, m, _) ->
@@ -169,10 +190,16 @@ let generate_transitions buffer start g protocol_name start_rec_vars =
     | Epsilon -> ()
   ) g ;
   Buffer.add_string buffer
-  "            _ => false
-  \        }\n\
-  \    }\n\
-  }\n"
+    "            _ => false\n\
+    \        }\n\
+    \    }\n"
+
+let generate_impl buffer start g protocol_name var_map rec_var_info =
+  Buffer.add_string buffer
+    (Printf.sprintf "impl %sMonitor {\n" protocol_name);
+  generate_constructor buffer start var_map rec_var_info;
+  generate_step_fn buffer g;
+  Buffer.add_string buffer "}\n"
 
 
 let gen_code (start, (g, rec_var_info)) ~protocol =
@@ -182,10 +209,6 @@ let gen_code (start, (g, rec_var_info)) ~protocol =
         Err.unimpl ~here:[%here]
           (Printf.sprintf "Rust codegen for silent recursion variable '%s'"
              (VariableName.user rv.rv_name))));
-  let start_rec_vars =
-    List.map ~f:snd
-      (Option.value ~default:[] (Map.find rec_var_info start))
-  in
   let buffer = Buffer.create 4096 in
   let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
   let var_map = compute_var_map start g rec_var_info in
@@ -197,5 +220,5 @@ let gen_code (start, (g, rec_var_info)) ~protocol =
   Buffer.add_string buffer "\n";
   generate_monitor buffer protocol_name;
   Buffer.add_string buffer "\n";
-  generate_transitions buffer start g protocol_name start_rec_vars;
+  generate_impl buffer start g protocol_name var_map rec_var_info;
   Buffer.contents buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -76,12 +76,28 @@ let generate_monitor buffer protocol_name =
   \    state: State,\n\
   }\n")
 
-let rec rust_value_pattern = function
-  | Expr.PTInt -> "Value::Int(_)"
-  | Expr.PTBool -> "Value::Bool(_)"
-  | Expr.PTString -> "Value::String(_)"
+let rust_keywords = Set.of_list (module String)
+  [ "as"; "break"; "const"; "continue"; "crate"; "else"; "enum"; "extern"
+  ; "false"; "fn"; "for"; "if"; "impl"; "in"; "let"; "loop"; "match"; "mod"
+  ; "move"; "mut"; "pub"; "ref"; "return"; "self"; "Self"; "static"; "struct"
+  ; "super"; "trait"; "true"; "type"; "unsafe"; "use"; "where"; "while" ]
+
+let validate_rust_ident v =
+  if Set.mem rust_keywords (VariableName.user v) then
+    Err.uerr (Err.RustKeywordConflict v)
+
+let rec rust_value_pattern name_opt = function
+  | Expr.PTInt ->
+      let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
+      Printf.sprintf "Value::Int(%s)" b
+  | Expr.PTBool ->
+      let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
+      Printf.sprintf "Value::Bool(%s)" b
+  | Expr.PTString ->
+      let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
+      Printf.sprintf "Value::String(%s)" b
   | Expr.PTUnit -> "Value::Unit"
-  | Expr.PTRefined (_, t, _) -> rust_value_pattern t
+  | Expr.PTRefined (_, t, _) -> rust_value_pattern name_opt t
   | Expr.PTAbstract n ->
       Err.unimpl ~here:[%here]
         (Printf.sprintf
@@ -92,7 +108,9 @@ let rec rust_value_pattern = function
 let payload_slice_pattern payloads =
   let patterns =
     List.filter_map payloads ~f:(function
-      | PValue (_, ty) -> Some (rust_value_pattern ty)
+      | PValue (name_opt, ty) ->
+          Option.iter name_opt ~f:validate_rust_ident;
+          Some (rust_value_pattern name_opt ty)
       | PDelegate _ -> None)
   in
   "[" ^ String.concat ~sep:", " patterns ^ "]"

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -4,7 +4,7 @@ open Efsm
 open Message
 
 (* Helpers *)
-let upper_camel_case s:string = 
+let upper_camel_case s:string =
   Stdlib.String.capitalize_ascii @@ Stdlib.String.lowercase_ascii s
 
 let int_to_name i = upper_camel_case @@ Int.to_string i
@@ -19,10 +19,10 @@ let collect_labels g =
   G.fold_edges_e f g (Set.empty (module String))
 
 (* Generators *)
-let generate_big_derive buffer = 
+let generate_big_derive buffer =
   Buffer.add_string buffer "#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n"
 
-let generate_small_derive buffer = 
+let generate_small_derive buffer =
   Buffer.add_string buffer "#[derive(Debug, Clone, PartialEq, Eq)]\n"
 
 let generate_states buffer g =
@@ -34,7 +34,7 @@ let generate_states buffer g =
   ) g;
   Buffer.add_string buffer "}\n"
 
-let generate_labels buffer g = 
+let generate_labels buffer g =
   let labels = collect_labels g in
   generate_big_derive buffer;
   Buffer.add_string buffer "pub enum Label {\n";
@@ -44,9 +44,9 @@ let generate_labels buffer g =
   );
   Buffer.add_string buffer "}\n"
 
-let generate_support_types buffer = 
+let generate_support_types buffer =
   generate_big_derive buffer;
-  Buffer.add_string buffer 
+  Buffer.add_string buffer
   "pub enum Direction {\n\
   \    Send,\n\
   \    Recv,\n\
@@ -69,56 +69,16 @@ let generate_support_types buffer =
   \    payloads: Vec<Value>,\n\
    }\n"
 
-let generate_monitor buffer protocol_name = 
+let generate_monitor buffer protocol_name =
   generate_small_derive buffer;
-  Buffer.add_string buffer 
+  Buffer.add_string buffer
   ("pub struct " ^ protocol_name ^ "Monitor {\n\
   \    state: State,\n\
   }\n")
 
-let rust_keywords = Set.of_list (module String)
-  [ "as"; "break"; "const"; "continue"; "crate"; "else"; "enum"; "extern"
-  ; "false"; "fn"; "for"; "if"; "impl"; "in"; "let"; "loop"; "match"; "mod"
-  ; "move"; "mut"; "pub"; "ref"; "return"; "self"; "Self"; "static"; "struct"
-  ; "super"; "trait"; "true"; "type"; "unsafe"; "use"; "where"; "while" ]
-
-let validate_rust_ident v =
-  if Set.mem rust_keywords (VariableName.user v) then
-    Err.uerr (Err.RustKeywordConflict v)
-
-let rec rust_value_pattern name_opt = function
-  | Expr.PTInt ->
-      let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
-      Printf.sprintf "Value::Int(%s)" b
-  | Expr.PTBool ->
-      let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
-      Printf.sprintf "Value::Bool(%s)" b
-  | Expr.PTString ->
-      let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
-      Printf.sprintf "Value::String(%s)" b
-  | Expr.PTUnit -> "Value::Unit"
-  | Expr.PTRefined (_, t, _) -> rust_value_pattern name_opt t
-  | Expr.PTAbstract n ->
-      Err.unimpl ~here:[%here]
-        (Printf.sprintf
-           "abstract payload type '%s' is not supported in Rust codegen; \
-            use bool, int, string or unit"
-           (PayloadTypeName.user n))
-
-let payload_slice_pattern payloads =
-  let patterns =
-    List.filter_map payloads ~f:(function
-      | PValue (name_opt, ty) ->
-          Option.iter name_opt ~f:validate_rust_ident;
-          Some (rust_value_pattern name_opt ty)
-      | PDelegate _ -> None)
-  in
-  "[" ^ String.concat ~sep:", " patterns ^ "]"
-
-let payload_constraints _ = "true"
 
 let generate_transitions buffer start g protocol_name =
-  Buffer.add_string buffer 
+  Buffer.add_string buffer
   ("impl " ^ protocol_name ^ "Monitor {\n\
   \    pub fn new() -> Self {\n\
   \        Self {\n\
@@ -145,9 +105,9 @@ let generate_transitions buffer start g protocol_name =
           (int_to_name src)
           dir
           (upper_camel_case (LabelName.user m.label))
-          (payload_slice_pattern m.payload)
+          (Rustexpr.payload_slice_pattern m.payload)
           (int_to_name dst)
-          (payload_constraints m.payload))
+          (Rustexpr.payload_constraints m.payload))
     | Epsilon -> ()
   ) g ;
   Buffer.add_string buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -175,7 +175,7 @@ let generate_constructor buffer start var_map rec_var_info =
 
 
 (* Match rec_expr_updates positionally to the rec vars at the destination
-   state. Returns (rv_name, let_binding_name, update_expr, rv_ty) tuples.
+   state. Returns (rv_name, new_binding_name, update_expr, rv_ty) tuples.
    Silent vars have been rejected earlier, so all dst rec vars are non-silent
    and the update count must match. *)
 let compute_rec_var_updates rannot dst_rv_info =
@@ -230,21 +230,14 @@ let generate_step_fn buffer g var_map rec_var_info =
   G.iter_edges_e (fun (src, a, dst) ->
     match a with
     | SendA (_, m, rannot) | RecvA (_, m, rannot) ->
-        let dir = match a with
-          | SendA _ -> "Send" | RecvA _ -> "Recv" | Epsilon -> assert false
-        in
+        let dir = match a with SendA _ -> "Send" | RecvA _ -> "Recv" | Epsilon -> assert false in
         let src_vars = Map.find_exn var_map src in
         let dst_vars = Map.find_exn var_map dst in
-        let dst_rv_info =
-          Option.value ~default:[] (Map.find rec_var_info dst)
-        in
+        let dst_rv_info = Option.value ~default:[] (Map.find rec_var_info dst) in
         let rec_var_updates = compute_rec_var_updates rannot dst_rv_info in
-        let new_rec_vars =
-          find_new_rec_vars src_vars dst_rv_info rec_var_updates in
-        let dst_field_inits =
-          build_dst_field_inits dst_vars rec_var_updates new_rec_vars in
-        let src_fields =
-          List.map src_vars ~f:(fun (v, _) -> VariableName.user v) in
+        let new_rec_vars = find_new_rec_vars src_vars dst_rv_info rec_var_updates in
+        let dst_field_inits = build_dst_field_inits dst_vars rec_var_updates new_rec_vars in
+        let src_fields = List.map src_vars ~f:(fun (v, _) -> VariableName.user v) in
 
         (* State + direction + label *)
         Buffer.add_string buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -52,11 +52,21 @@ let generate_support_types buffer =
   \    Recv,\n\
    }\n\
   \n";
-  generate_big_derive buffer;
-  Buffer.add_string buffer 
+  generate_small_derive buffer;
+  Buffer.add_string buffer
+  "pub enum Value {\n\
+  \    Int(i64),\n\
+  \    Bool(bool),\n\
+  \    String(String),\n\
+  \    Unit,\n\
+   }\n\
+  \n";
+  generate_small_derive buffer;
+  Buffer.add_string buffer
   "pub struct Action {\n\
   \    dir: Direction,\n\
   \    label: Label,\n\
+  \    payloads: Vec<Value>,\n\
    }\n"
 
 let generate_monitor buffer protocol_name = 
@@ -102,10 +112,32 @@ let generate_transitions buffer start g protocol_name =
   "            _ => false
   \        }\n\
   \    }\n\
+  \
+  \    fn 
   }\n"
+
+let rec has_abstract_payload_type = function
+  | Expr.PTAbstract _ -> true
+  | Expr.PTRefined (_, t, _) -> has_abstract_payload_type t
+  | _ -> false
+
+let validate_no_abstract_payloads g =
+  G.iter_edges_e (fun (_, a, _) ->
+    match a with
+    | SendA (_, m, _) | RecvA (_, m, _) ->
+        List.iter m.payload ~f:(function
+          | PValue (_, ty) when has_abstract_payload_type ty ->
+              Err.unimpl ~here:[%here]
+                (Printf.sprintf
+                   "abstract payload type '%s' is not supported in Rust codegen \n use bool, int, string or unit"
+                   (PayloadTypeName.user (Expr.payload_typename_of_payload_type ty)))
+          | _ -> ())
+    | Epsilon -> ()
+  ) g
 
 (* let gen_code (start, (g, rec_var_info)) ~protocol =  *)
 let gen_code (start, (g,_)) ~protocol =
+  validate_no_abstract_payloads g;
   let buffer = Buffer.create 4096 in
   let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
   generate_states buffer g;

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -76,6 +76,27 @@ let generate_monitor buffer protocol_name =
   \    state: State,\n\
   }\n")
 
+let rec rust_value_pattern = function
+  | Expr.PTInt -> "Value::Int(_)"
+  | Expr.PTBool -> "Value::Bool(_)"
+  | Expr.PTString -> "Value::String(_)"
+  | Expr.PTUnit -> "Value::Unit"
+  | Expr.PTRefined (_, t, _) -> rust_value_pattern t
+  | Expr.PTAbstract n ->
+      Err.unimpl ~here:[%here]
+        (Printf.sprintf
+           "abstract payload type '%s' is not supported in Rust codegen; \
+            use bool, int, string or unit"
+           (PayloadTypeName.user n))
+
+let payload_slice_pattern payloads =
+  let patterns =
+    List.filter_map payloads ~f:(function
+      | PValue (_, ty) -> Some (rust_value_pattern ty)
+      | PDelegate _ -> None)
+  in
+  "[" ^ String.concat ~sep:", " patterns ^ "]"
+
 let generate_transitions buffer start g protocol_name =
   Buffer.add_string buffer 
   ("impl " ^ protocol_name ^ "Monitor {\n\
@@ -90,21 +111,21 @@ let generate_transitions buffer start g protocol_name =
   ");
   G.iter_edges_e (fun (src, a, dst) ->
     match a with
-    | SendA (_, m, _) ->
+    | SendA (_, m, _) | RecvA (_, m, _) ->
+      let dir = match a with
+        | SendA _ -> "Send" | RecvA _ -> "Recv" | Epsilon -> assert false
+      in
       Buffer.add_string buffer
         (Printf.sprintf
-          "            (State::S%s, Direction::Send, Label::%s) \
-            => { self.state = State::S%s; true }\n"
+          "            (State::S%s, Direction::%s, Label::%s) => \
+           match action.payloads.as_slice() {\n\
+           \                %s => { self.state = State::S%s; true }\n\
+           \                _ => false\n\
+           \            },\n"
           (int_to_name src)
+          dir
           (upper_camel_case (LabelName.user m.label))
-          (int_to_name dst))
-    | RecvA (_, m, _) ->
-      Buffer.add_string buffer
-        (Printf.sprintf
-          "            (State::S%s, Direction::Recv, Label::%s) \
-          => { self.state = State::S%s; true }\n"
-          (int_to_name src)
-          (upper_camel_case (LabelName.user m.label))
+          (payload_slice_pattern m.payload)
           (int_to_name dst))
     | Epsilon -> ()
   ) g ;
@@ -112,32 +133,11 @@ let generate_transitions buffer start g protocol_name =
   "            _ => false
   \        }\n\
   \    }\n\
-  \
-  \    fn 
   }\n"
 
-let rec has_abstract_payload_type = function
-  | Expr.PTAbstract _ -> true
-  | Expr.PTRefined (_, t, _) -> has_abstract_payload_type t
-  | _ -> false
-
-let validate_no_abstract_payloads g =
-  G.iter_edges_e (fun (_, a, _) ->
-    match a with
-    | SendA (_, m, _) | RecvA (_, m, _) ->
-        List.iter m.payload ~f:(function
-          | PValue (_, ty) when has_abstract_payload_type ty ->
-              Err.unimpl ~here:[%here]
-                (Printf.sprintf
-                   "abstract payload type '%s' is not supported in Rust codegen \n use bool, int, string or unit"
-                   (PayloadTypeName.user (Expr.payload_typename_of_payload_type ty)))
-          | _ -> ())
-    | Epsilon -> ()
-  ) g
 
 (* let gen_code (start, (g, rec_var_info)) ~protocol =  *)
 let gen_code (start, (g,_)) ~protocol =
-  validate_no_abstract_payloads g;
   let buffer = Buffer.create 4096 in
   let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
   generate_states buffer g;

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -69,21 +69,33 @@ let generate_support_types buffer =
   \    payloads: Vec<Value>,\n\
    }\n"
 
-let generate_monitor buffer protocol_name =
+let generate_monitor buffer protocol_name start_rec_vars =
   generate_small_derive buffer;
   Buffer.add_string buffer
-  ("pub struct " ^ protocol_name ^ "Monitor {\n\
-  \    state: State,\n\
-  }\n")
+    ("pub struct " ^ protocol_name ^ "Monitor {\n\
+    \    state: State,\n");
+  List.iter start_rec_vars ~f:(fun (rv : Gtype.rec_var) ->
+    Rustexpr.validate_rust_ident rv.rv_name;
+    Buffer.add_string buffer
+      (Printf.sprintf "    %s: %s,\n"
+         (VariableName.user rv.rv_name)
+         (Rustexpr.rust_type_of_payload_type rv.rv_ty)));
+  Buffer.add_string buffer "}\n"
 
 
-let generate_transitions buffer start g protocol_name =
+let generate_transitions buffer start g protocol_name start_rec_vars =
   Buffer.add_string buffer
   ("impl " ^ protocol_name ^ "Monitor {\n\
   \    pub fn new() -> Self {\n\
   \        Self {\n\
-  \            state: State::S" ^ (Int.to_string start) ^ "\n\
-  \        }\n\
+  \            state: State::S" ^ (Int.to_string start) ^ ",\n");
+  List.iter start_rec_vars ~f:(fun (rv : Gtype.rec_var) ->
+    Buffer.add_string buffer
+      (Printf.sprintf "            %s: %s,\n"
+         (VariableName.user rv.rv_name)
+         (Rustexpr.rust_show_expr rv.rv_init_expr)));
+  Buffer.add_string buffer
+  ("        }\n\
   \    }\n\
   \n\
   \    pub fn step(&mut self, action: &Action) -> bool {\n\
@@ -117,8 +129,17 @@ let generate_transitions buffer start g protocol_name =
   }\n"
 
 
-(* let gen_code (start, (g, rec_var_info)) ~protocol =  *)
-let gen_code (start, (g,_)) ~protocol =
+let gen_code (start, (g, rec_var_info)) ~protocol =
+  Map.iter rec_var_info ~f:(fun data ->
+    List.iter data ~f:(fun (is_silent, (rv : Gtype.rec_var)) ->
+      if is_silent then
+        Err.unimpl ~here:[%here]
+          (Printf.sprintf "Rust codegen for silent recursion variable '%s'"
+             (VariableName.user rv.rv_name))));
+  let start_rec_vars =
+    List.map ~f:snd
+      (Option.value ~default:[] (Map.find rec_var_info start))
+  in
   let buffer = Buffer.create 4096 in
   let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
   generate_states buffer g;
@@ -127,7 +148,7 @@ let gen_code (start, (g,_)) ~protocol =
   Buffer.add_string buffer "\n";
   generate_support_types buffer;
   Buffer.add_string buffer "\n";
-  generate_monitor buffer protocol_name;
+  generate_monitor buffer protocol_name start_rec_vars;
   Buffer.add_string buffer "\n";
-  generate_transitions buffer start g protocol_name;
+  generate_transitions buffer start g protocol_name start_rec_vars;
   Buffer.contents buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -1,5 +1,6 @@
 open! Base
 open Names
+open Gtype
 open Efsm
 open Message
 
@@ -29,7 +30,7 @@ let compute_var_map start g rec_var_info =
     | None ->
         let rec_vars =
           Option.value ~default:[] (Map.find rec_var_info curr_st)
-          |> List.map ~f:(fun (_, (rv : Gtype.rec_var)) -> (rv.rv_name, rv.rv_ty))
+          |> List.map ~f:(fun (_, rv) -> (rv.rv_name, rv.rv_ty))
         in
         let vars = List.fold ~f:append_var ~init:vars rec_vars in
         let acc = Map.set acc ~key:curr_st ~data:vars in
@@ -62,12 +63,25 @@ let generate_big_derive buffer =
 let generate_small_derive buffer =
   Buffer.add_string buffer "#[derive(Debug, Clone, PartialEq, Eq)]\n"
 
-let generate_states buffer g =
-  generate_big_derive buffer;
+let generate_state_enum buffer var_map g =
+  generate_small_derive buffer;
   Buffer.add_string buffer "enum State {\n";
-  G.iter_vertex (fun label ->
-    Buffer.add_string buffer
-    ("\    S" ^ (Int.to_string label) ^ ",\n")
+  G.iter_vertex (fun state ->
+    let vars = Map.find_exn var_map state in
+    match vars with
+    | [] ->
+        Buffer.add_string buffer
+          (Printf.sprintf "    S%d,\n" state)
+    | _ ->
+        let fields =
+          List.map vars ~f:(fun (v, ty) ->
+            Printf.sprintf "%s: %s"
+              (VariableName.user v)
+              (Rustexpr.rust_type_of_payload_type ty))
+        in
+        Buffer.add_string buffer
+          (Printf.sprintf "    S%d { %s },\n" state
+             (String.concat ~sep:", " fields))
   ) g;
   Buffer.add_string buffer "}\n"
 
@@ -106,18 +120,13 @@ let generate_support_types buffer =
   \    payloads: Vec<Value>,\n\
    }\n"
 
-let generate_monitor buffer protocol_name start_rec_vars =
+let generate_monitor buffer protocol_name =
   generate_small_derive buffer;
   Buffer.add_string buffer
-    ("pub struct " ^ protocol_name ^ "Monitor {\n\
-    \    state: State,\n");
-  List.iter start_rec_vars ~f:(fun (rv : Gtype.rec_var) ->
-    Rustexpr.validate_rust_ident rv.rv_name;
-    Buffer.add_string buffer
-      (Printf.sprintf "    %s: %s,\n"
-         (VariableName.user rv.rv_name)
-         (Rustexpr.rust_type_of_payload_type rv.rv_ty)));
-  Buffer.add_string buffer "}\n"
+    (Printf.sprintf
+       "pub struct %sMonitor {\n\
+       \    state: State,\n\
+        }\n" protocol_name)
 
 
 let generate_transitions buffer start g protocol_name start_rec_vars =
@@ -126,7 +135,7 @@ let generate_transitions buffer start g protocol_name start_rec_vars =
   \    pub fn new() -> Self {\n\
   \        Self {\n\
   \            state: State::S" ^ (Int.to_string start) ^ ",\n");
-  List.iter start_rec_vars ~f:(fun (rv : Gtype.rec_var) ->
+  List.iter start_rec_vars ~f:(fun rv ->
     Buffer.add_string buffer
       (Printf.sprintf "            %s: %s,\n"
          (VariableName.user rv.rv_name)
@@ -168,7 +177,7 @@ let generate_transitions buffer start g protocol_name start_rec_vars =
 
 let gen_code (start, (g, rec_var_info)) ~protocol =
   Map.iter rec_var_info ~f:(fun data ->
-    List.iter data ~f:(fun (is_silent, (rv : Gtype.rec_var)) ->
+    List.iter data ~f:(fun (is_silent, rv) ->
       if is_silent then
         Err.unimpl ~here:[%here]
           (Printf.sprintf "Rust codegen for silent recursion variable '%s'"
@@ -179,13 +188,14 @@ let gen_code (start, (g, rec_var_info)) ~protocol =
   in
   let buffer = Buffer.create 4096 in
   let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
-  generate_states buffer g;
+  let var_map = compute_var_map start g rec_var_info in
+  generate_state_enum buffer var_map g;
   Buffer.add_string buffer "\n";
   generate_labels buffer g;
   Buffer.add_string buffer "\n";
   generate_support_types buffer;
   Buffer.add_string buffer "\n";
-  generate_monitor buffer protocol_name start_rec_vars;
+  generate_monitor buffer protocol_name;
   Buffer.add_string buffer "\n";
   generate_transitions buffer start g protocol_name start_rec_vars;
   Buffer.contents buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -3,12 +3,11 @@ open Names
 open Gtype
 open Efsm
 open Message
+open Syntax
 
 (* Helpers *)
 let upper_camel_case s:string =
   Stdlib.String.capitalize_ascii @@ Stdlib.String.lowercase_ascii s
-
-let int_to_name i = upper_camel_case @@ Int.to_string i
 
 let find_payload_vars m =
   List.filter_map m.payload ~f:(function
@@ -128,6 +127,12 @@ let generate_monitor buffer protocol_name =
        \    state: State,\n\
         }\n" protocol_name)
 
+let fmt_state_variant state fields =
+  match fields with
+  | [] -> Printf.sprintf "S%d" state
+  | _ ->
+      Printf.sprintf "S%d { %s }" state
+        (String.concat ~sep:", " fields)
 
 let generate_constructor buffer start var_map rec_var_info =
   let start_vars = Map.find_exn var_map start in
@@ -143,52 +148,146 @@ let generate_constructor buffer start var_map rec_var_info =
       Err.violationf ~here:[%here]
         "Payload variable '%s' at start state has no initial value"
         (VariableName.user v));
-  Buffer.add_string buffer "    pub fn new() -> Self {\n";
-  (match start_vars with
-   | [] ->
-       Buffer.add_string buffer
-         (Printf.sprintf "        Self { state: State::S%d }\n" start)
-   | _ ->
-       let inits =
-         List.map start_vars ~f:(fun (v, _) ->
-           let (_, rv) = List.find_exn start_rv_info
-             ~f:(fun (_, rv) -> VariableName.equal v rv.rv_name)
-           in
-           Printf.sprintf "%s: %s"
-             (VariableName.user v)
-             (Rustexpr.rust_show_expr rv.rv_init_expr))
-       in
-       Buffer.add_string buffer
-         (Printf.sprintf "        Self { state: State::S%d { %s } }\n"
-            start (String.concat ~sep:", " inits)));
-  Buffer.add_string buffer "    }\n"
+  let inits =
+    List.map start_vars ~f:(fun (v, _) ->
+      let (_, rv) = List.find_exn start_rv_info
+        ~f:(fun (_, rv) -> VariableName.equal v rv.rv_name)
+      in
+      Printf.sprintf "%s: %s"
+        (VariableName.user v)
+        (Rustexpr.rust_show_expr rv.rv_init_expr))
+  in
+  Buffer.add_string buffer
+    (Printf.sprintf
+       "    pub fn new() -> Self {\n\
+       \        Self { state: State::%s }\n\
+       \    }\n"
+       (fmt_state_variant start inits))
 
-let generate_step_fn buffer g =
+
+(* Match rec_expr_updates positionally to the rec vars at the destination
+   state. Returns (rv_name, let_binding_name, update_expr, rv_ty) tuples.
+   Silent vars have been rejected earlier, so all dst rec vars are non-silent
+   and the update count must match. *)
+let compute_rec_var_updates rannot dst_rv_info =
+  let n_updates = List.length rannot.rec_expr_updates in
+  let n_rec_vars = List.length dst_rv_info in
+  if n_updates > n_rec_vars then
+    Err.violationf ~here:[%here]
+      "More rec_expr_updates (%d) than destination rec vars (%d)"
+      n_updates n_rec_vars;
+  let paired =
+    List.zip_exn rannot.rec_expr_updates
+      (List.take dst_rv_info n_updates)
+  in
+  List.map paired ~f:(fun (e, (_, rv)) ->
+    let binding = "new_" ^ VariableName.user rv.rv_name in
+    (rv.rv_name, binding, e, rv.rv_ty))
+
+(* Rec vars at dst that are neither carried from src nor updated by the
+   transition — these are newly entering scope and get their init expr. *)
+let find_new_rec_vars src_vars dst_rv_info rec_var_updates =
+  List.filter_map dst_rv_info ~f:(fun (_, rv) ->
+    let in_src = List.exists src_vars
+      ~f:(fun (v, _) -> VariableName.equal v rv.rv_name) in
+    let has_update = List.exists rec_var_updates
+      ~f:(fun (name, _, _, _) -> VariableName.equal name rv.rv_name) in
+    if (not in_src) && (not has_update) then
+      Some (rv.rv_name, Rustexpr.rust_show_expr rv.rv_init_expr)
+    else None)
+
+(* Build the field initializer list for the destination state variant.
+   Each dst var is either: an updated rec var (new_x), a newly initialized
+   rec var, or carried through unchanged (shorthand field init). *)
+let build_dst_field_inits dst_vars rec_var_updates new_rec_vars =
+  List.map dst_vars ~f:(fun (v, _) ->
+    let name = VariableName.user v in
+    match List.find rec_var_updates
+            ~f:(fun (rv, _, _, _) -> VariableName.equal v rv) with
+    | Some (_, binding, _, _) ->
+        Printf.sprintf "%s: %s" name binding
+    | None ->
+    match List.find new_rec_vars
+            ~f:(fun (rv, _) -> VariableName.equal v rv) with
+    | Some (_, init_expr) ->
+        Printf.sprintf "%s: %s" name init_expr
+    | None -> name)
+
+let generate_step_fn buffer g var_map rec_var_info =
   Buffer.add_string buffer
     "\n\
     \    pub fn step(&mut self, action: &Action) -> bool {\n\
-    \        match (self.state, action.dir, action.label) {\n";
+    \        match (&self.state, &action.dir, &action.label) {\n";
   G.iter_edges_e (fun (src, a, dst) ->
     match a with
-    | SendA (_, m, _) | RecvA (_, m, _) ->
-      let dir = match a with
-        | SendA _ -> "Send" | RecvA _ -> "Recv" | Epsilon -> assert false
-      in
-      Buffer.add_string buffer
-        (Printf.sprintf
-          "            (State::S%s, Direction::%s, Label::%s) => \
-           match action.payloads.as_slice() {\n\
-           \                %s => { self.state = State::S%s; %s }\n\
-           \                _ => false\n\
-           \            },\n"
-          (int_to_name src)
-          dir
-          (upper_camel_case (LabelName.user m.label))
-          (Rustexpr.payload_slice_pattern m.payload)
-          (int_to_name dst)
-          (Rustexpr.payload_constraints m.payload))
+    | SendA (_, m, rannot) | RecvA (_, m, rannot) ->
+        let dir = match a with
+          | SendA _ -> "Send" | RecvA _ -> "Recv" | Epsilon -> assert false
+        in
+        let src_vars = Map.find_exn var_map src in
+        let dst_vars = Map.find_exn var_map dst in
+        let dst_rv_info =
+          Option.value ~default:[] (Map.find rec_var_info dst)
+        in
+        let rec_var_updates = compute_rec_var_updates rannot dst_rv_info in
+        let new_rec_vars =
+          find_new_rec_vars src_vars dst_rv_info rec_var_updates in
+        let field_inits =
+          build_dst_field_inits dst_vars rec_var_updates new_rec_vars in
+        let src_fields =
+          List.map src_vars ~f:(fun (v, _) -> VariableName.user v) in
+
+        (* State + direction + label *)
+        Buffer.add_string buffer
+          (Printf.sprintf
+             "            (State::%s, Direction::%s, Label::%s) =>\n"
+             (fmt_state_variant src src_fields) dir
+             (upper_camel_case (LabelName.user m.label)));
+
+        (* Payload match *)
+        Buffer.add_string buffer
+          (Printf.sprintf
+             "                match action.payloads.as_slice() {\n\
+             \                    %s => {\n"
+             (Rustexpr.payload_slice_pattern m.payload));
+
+        (* Payload constraints *)
+        Option.iter (Rustexpr.payload_constraints m.payload) ~f:(fun c ->
+          Buffer.add_string buffer
+            (Printf.sprintf
+               "                        if !(%s) { return false; }\n" c));
+
+        (* Rec var update let-bindings *)
+        List.iter rec_var_updates ~f:(fun (_, binding, expr, _) ->
+          Buffer.add_string buffer
+            (Printf.sprintf "                        let %s = %s;\n"
+               binding (Rustexpr.rust_show_expr expr)));
+
+        (* Rec var type constraints (on updated values only) *)
+        List.iter rec_var_updates ~f:(fun (_, binding, _, rv_ty) ->
+          match rv_ty with
+          | Expr.PTRefined (binder, _, pred) ->
+              let pred =
+                Expr.substitute ~from:binder
+                  ~replace:(Var (VariableName.of_string binding)) pred
+              in
+              Buffer.add_string buffer
+                (Printf.sprintf
+                   "                        if !(%s) { return false; }\n"
+                   (Rustexpr.rust_show_expr pred))
+          | _ -> ());
+
+        (* Transition to next state *)
+        Buffer.add_string buffer
+          (Printf.sprintf
+             "                        self.state = State::%s;\n\
+             \                        true\n\
+             \                    }\n\
+             \                    _ => false\n\
+             \                },\n"
+             (fmt_state_variant dst field_inits))
     | Epsilon -> ()
-  ) g ;
+  ) g;
   Buffer.add_string buffer
     "            _ => false\n\
     \        }\n\
@@ -198,7 +297,7 @@ let generate_impl buffer start g protocol_name var_map rec_var_info =
   Buffer.add_string buffer
     (Printf.sprintf "impl %sMonitor {\n" protocol_name);
   generate_constructor buffer start var_map rec_var_info;
-  generate_step_fn buffer g;
+  generate_step_fn buffer g var_map rec_var_info;
   Buffer.add_string buffer "}\n"
 
 

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -4,67 +4,8 @@ open Gtype
 open Efsm
 open Message
 open Syntax
+open Rustefsm
 
-(* Helpers *)
-let upper_camel_case s:string =
-  Stdlib.String.capitalize_ascii @@ Stdlib.String.lowercase_ascii s
-
-let find_payload_vars m =
-  List.filter_map m.payload ~f:(function
-    | PValue (Some v, ty) -> Some (v, ty)
-    | _ -> None)
-
-let append_var lst ((v, _) as entry) =
-  if List.exists lst ~f:(fun (v_, _) -> VariableName.equal v v_) then lst
-  else lst @ [entry]
-
-let rm_silent_var rec_var_info =
-  Map.map rec_var_info ~f:(fun data ->
-    List.map data ~f:(fun (is_silent, rv) ->
-      if is_silent then
-        Err.unimpl ~here:[%here]
-          (Printf.sprintf "Rust codegen for silent recursion variable '%s'"
-            (VariableName.user rv.rv_name))
-      else rv))
-
-(* Walk the EFSM graph from [start], accumulating rec vars and named payload
-   vars along each path. Each state is visited at most once: when choice
-   branches merge into a single state, session-type merging guarantees
-   identical variable scopes on every path, so the first visit suffices. *)
-let compute_var_map start g rec_var_info =
-  let rec aux acc (curr_st, vars) =
-    match Map.find acc curr_st with
-    | Some _ -> acc
-    | None ->
-        let rec_vars =
-          Option.value ~default:[] (Map.find rec_var_info curr_st)
-          |> List.map ~f:(fun rv -> (rv.rv_name, rv.rv_ty))
-        in
-        let vars = List.fold ~f:append_var ~init:vars rec_vars in
-        let acc = Map.set acc ~key:curr_st ~data:vars in
-        G.fold_succ_e (fun (_, action, next_st) acc ->
-          match action with
-          | SendA (_, m, _) | RecvA (_, m, _) ->
-              let payload_vars = find_payload_vars m in
-              let vars = List.fold ~f:append_var ~init:vars payload_vars in
-              aux acc (next_st, vars)
-          | Epsilon ->
-              Err.violation ~here:[%here]
-                "Epsilon transitions should not appear in EFSM outputs"
-        ) g curr_st acc
-  in
-  aux (Map.empty (module Int)) (start, [])
-
-let collect_labels g =
-  let f (_, a, _) acc =
-    match a with
-    | SendA (_, m, _) | RecvA (_, m, _) ->
-        Set.add acc (LabelName.user m.label)
-    | Epsilon -> acc
-  in
-  G.fold_edges_e f g (Set.empty (module String))
-
-(* Generators *)
 let generate_big_derive buffer =
   Buffer.add_string buffer "#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n"
 
@@ -174,10 +115,7 @@ let generate_constructor buffer start var_map rec_var_info =
        (fmt_state_variant start inits))
 
 
-(* Match rec_expr_updates positionally to the rec vars at the destination
-   state. Returns (rv_name, new_binding_name, update_expr, rv_ty) tuples.
-   Silent vars have been rejected earlier, so all dst rec vars are non-silent
-   and the update count must match. *)
+(* Precondition: silent vars have been stripped by [rm_silent_var]. *)
 let compute_rec_var_updates rannot dst_rv_info =
   let n_updates = List.length rannot.rec_expr_updates in
   let n_rec_vars = List.length dst_rv_info in
@@ -193,8 +131,6 @@ let compute_rec_var_updates rannot dst_rv_info =
     let binding = "new_" ^ VariableName.user rv.rv_name in
     (rv.rv_name, binding, e, rv.rv_ty))
 
-(* Rec vars at dst that are neither carried from src nor updated by the
-   transition — these are newly entering scope and get their init expr. *)
 let find_new_rec_vars src_vars dst_rv_info rec_var_updates =
   List.filter_map dst_rv_info ~f:(fun rv ->
     let in_src = List.exists src_vars
@@ -205,22 +141,21 @@ let find_new_rec_vars src_vars dst_rv_info rec_var_updates =
       Some (rv.rv_name, Rustexpr.rust_show_expr rv.rv_init_expr)
     else None)
 
-(* Build the field initializer list for the destination state variant.
-   Each dst var is either: an updated rec var (new_x), a newly initialized
-   rec var, or carried through unchanged (shorthand field init). *)
 let build_dst_field_inits dst_vars rec_var_updates new_rec_vars =
   List.map dst_vars ~f:(fun (v, _) ->
     let name = VariableName.user v in
-    match List.find rec_var_updates
-            ~f:(fun (rv, _, _, _) -> VariableName.equal v rv) with
-    | Some (_, binding, _, _) ->
-        Printf.sprintf "%s: %s" name binding
-    | None ->
-    match List.find new_rec_vars
-            ~f:(fun (rv, _) -> VariableName.equal v rv) with
-    | Some (_, init_expr) ->
-        Printf.sprintf "%s: %s" name init_expr
-    | None -> name)
+    let updated_binding =
+      List.find_map rec_var_updates
+        ~f:(fun (rv, binding, _, _) -> Option.some_if (VariableName.equal v rv) binding)
+    in
+    let init_expr =
+      List.find_map new_rec_vars
+        ~f:(fun (rv, expr) -> Option.some_if (VariableName.equal v rv) expr)
+    in
+    match updated_binding, init_expr with
+    | Some binding, _ -> Printf.sprintf "%s: %s" name binding
+    | None, Some expr  -> Printf.sprintf "%s: %s" name expr
+    | None, None       -> name)
 
 let generate_step_fn buffer g var_map rec_var_info =
   Buffer.add_string buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -18,6 +18,15 @@ let append_var lst ((v, _) as entry) =
   if List.exists lst ~f:(fun (v_, _) -> VariableName.equal v v_) then lst
   else lst @ [entry]
 
+let rm_silent_var rec_var_info =
+  Map.map rec_var_info ~f:(fun data ->
+    List.map data ~f:(fun (is_silent, rv) ->
+      if is_silent then
+        Err.unimpl ~here:[%here]
+          (Printf.sprintf "Rust codegen for silent recursion variable '%s'"
+            (VariableName.user rv.rv_name))
+      else rv))
+
 (* Walk the EFSM graph from [start], accumulating rec vars and named payload
    vars along each path. Each state is visited at most once: when choice
    branches merge into a single state, session-type merging guarantees
@@ -29,7 +38,7 @@ let compute_var_map start g rec_var_info =
     | None ->
         let rec_vars =
           Option.value ~default:[] (Map.find rec_var_info curr_st)
-          |> List.map ~f:(fun (_, rv) -> (rv.rv_name, rv.rv_ty))
+          |> List.map ~f:(fun rv -> (rv.rv_name, rv.rv_ty))
         in
         let vars = List.fold ~f:append_var ~init:vars rec_vars in
         let acc = Map.set acc ~key:curr_st ~data:vars in
@@ -119,7 +128,7 @@ let generate_support_types buffer =
   \    payloads: Vec<Value>,\n\
    }\n"
 
-let generate_monitor buffer protocol_name =
+let generate_monitor_struct buffer protocol_name =
   generate_small_derive buffer;
   Buffer.add_string buffer
     (Printf.sprintf
@@ -142,7 +151,7 @@ let generate_constructor buffer start var_map rec_var_info =
   List.iter start_vars ~f:(fun (v, _) ->
     let is_rec_var =
       List.exists start_rv_info
-        ~f:(fun (_, rv) -> VariableName.equal v rv.rv_name)
+        ~f:(fun rv -> VariableName.equal v rv.rv_name)
     in
     if not is_rec_var then
       Err.violationf ~here:[%here]
@@ -150,8 +159,8 @@ let generate_constructor buffer start var_map rec_var_info =
         (VariableName.user v));
   let inits =
     List.map start_vars ~f:(fun (v, _) ->
-      let (_, rv) = List.find_exn start_rv_info
-        ~f:(fun (_, rv) -> VariableName.equal v rv.rv_name)
+      let rv = List.find_exn start_rv_info
+        ~f:(fun rv -> VariableName.equal v rv.rv_name)
       in
       Printf.sprintf "%s: %s"
         (VariableName.user v)
@@ -180,14 +189,14 @@ let compute_rec_var_updates rannot dst_rv_info =
     List.zip_exn rannot.rec_expr_updates
       (List.take dst_rv_info n_updates)
   in
-  List.map paired ~f:(fun (e, (_, rv)) ->
+  List.map paired ~f:(fun (e, rv) ->
     let binding = "new_" ^ VariableName.user rv.rv_name in
     (rv.rv_name, binding, e, rv.rv_ty))
 
 (* Rec vars at dst that are neither carried from src nor updated by the
    transition — these are newly entering scope and get their init expr. *)
 let find_new_rec_vars src_vars dst_rv_info rec_var_updates =
-  List.filter_map dst_rv_info ~f:(fun (_, rv) ->
+  List.filter_map dst_rv_info ~f:(fun rv ->
     let in_src = List.exists src_vars
       ~f:(fun (v, _) -> VariableName.equal v rv.rv_name) in
     let has_update = List.exists rec_var_updates
@@ -232,7 +241,7 @@ let generate_step_fn buffer g var_map rec_var_info =
         let rec_var_updates = compute_rec_var_updates rannot dst_rv_info in
         let new_rec_vars =
           find_new_rec_vars src_vars dst_rv_info rec_var_updates in
-        let field_inits =
+        let dst_field_inits =
           build_dst_field_inits dst_vars rec_var_updates new_rec_vars in
         let src_fields =
           List.map src_vars ~f:(fun (v, _) -> VariableName.user v) in
@@ -249,7 +258,7 @@ let generate_step_fn buffer g var_map rec_var_info =
           (Printf.sprintf
              "                match action.payloads.as_slice() {\n\
              \                    %s => {\n"
-             (Rustexpr.payload_slice_pattern m.payload));
+             (Rustexpr.rust_payload_slice_pattern m.payload));
 
         (* Clone payload bindings from slice refs to owned values *)
         let payload_vars = find_payload_vars m in
@@ -260,7 +269,7 @@ let generate_step_fn buffer g var_map rec_var_info =
                name name));
 
         (* Payload constraints *)
-        Option.iter (Rustexpr.payload_constraints m.payload) ~f:(fun c ->
+        Option.iter (Rustexpr.rust_payload_constraints m.payload) ~f:(fun c ->
           Buffer.add_string buffer
             (Printf.sprintf
                "                        if !(%s) { return false; }\n" c));
@@ -293,7 +302,7 @@ let generate_step_fn buffer g var_map rec_var_info =
              \                    }\n\
              \                    _ => false\n\
              \                },\n"
-             (fmt_state_variant dst field_inits))
+             (fmt_state_variant dst dst_field_inits))
     | Epsilon -> ()
   ) g;
   Buffer.add_string buffer
@@ -310,22 +319,18 @@ let generate_impl buffer start g protocol_name var_map rec_var_info =
 
 
 let gen_code (start, (g, rec_var_info)) ~protocol =
-  Map.iter rec_var_info ~f:(fun data ->
-    List.iter data ~f:(fun (is_silent, rv) ->
-      if is_silent then
-        Err.unimpl ~here:[%here]
-          (Printf.sprintf "Rust codegen for silent recursion variable '%s'"
-             (VariableName.user rv.rv_name))));
-  let buffer = Buffer.create 4096 in
-  let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
+  let rec_var_info = rm_silent_var rec_var_info in
   let var_map = compute_var_map start g rec_var_info in
+  let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
+
+  let buffer = Buffer.create 4096 in
   generate_state_enum buffer var_map g;
   Buffer.add_string buffer "\n";
   generate_labels buffer g;
   Buffer.add_string buffer "\n";
   generate_support_types buffer;
   Buffer.add_string buffer "\n";
-  generate_monitor buffer protocol_name;
+  generate_monitor_struct buffer protocol_name;
   Buffer.add_string buffer "\n";
   generate_impl buffer start g protocol_name var_map rec_var_info;
   Buffer.contents buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -1,0 +1,62 @@
+open! Base
+open Names
+open Efsm
+open Message
+
+(* Helpers *)
+let upper_camel_case s:string = 
+  Stdlib.String.capitalize_ascii @@ Stdlib.String.lowercase_ascii s
+
+let collect_labels g =
+  let f (_, a, _) acc =
+    match a with
+    | SendA (_, m, _) | RecvA (_, m, _) ->
+        Set.add acc (LabelName.user m.label)
+    | Epsilon -> acc
+  in
+  G.fold_edges_e f g (Set.empty (module String))
+
+(* Generators *)
+let generate_derive buffer = 
+  Buffer.add_string buffer "#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n"
+
+let generate_labels buffer g = 
+  let labels = collect_labels g in
+  generate_derive buffer;
+  Buffer.add_string buffer
+  "enum Label {\n";
+  Set.iter labels ~f:(fun label ->
+    Buffer.add_string buffer
+    ("\    " ^ (upper_camel_case label) ^ ",\n")
+  );
+  Buffer.add_string buffer "}\n"
+
+let generate_support_types buffer = 
+  generate_derive buffer;
+  Buffer.add_string buffer 
+  "enum Direction {\n\
+  \    Send,\n\
+  \    Recv,\n\
+   }\n\
+  \n";
+  generate_derive buffer;
+  Buffer.add_string buffer 
+  "struct Action {\n\
+  \    dir: Direction,\n\
+  \    label: Label,\n\
+   }\n"
+
+let generate_monitor buffer protocol = 
+  generate_derive buffer;
+  Buffer.add_string buffer ("pub struct " ^ protocol ^ "Monitor; \n")
+
+(* let gen_code (start, (g, rec_var_info)) ~protocol =  *)
+let gen_code (_, (g,_)) ~protocol =
+  let buffer = Buffer.create 4096 in
+  let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
+  generate_labels buffer g;
+  Buffer.add_string buffer "\n";
+  generate_support_types buffer;
+  Buffer.add_string buffer "\n";
+  generate_monitor buffer protocol_name;
+  Buffer.contents buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -19,22 +19,25 @@ let collect_labels g =
   G.fold_edges_e f g (Set.empty (module String))
 
 (* Generators *)
-let generate_derive buffer = 
+let generate_big_derive buffer = 
   Buffer.add_string buffer "#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n"
 
+let generate_small_derive buffer = 
+  Buffer.add_string buffer "#[derive(Debug, Clone, PartialEq, Eq)]\n"
+
 let generate_states buffer g =
-  generate_derive buffer;
+  generate_big_derive buffer;
   Buffer.add_string buffer "enum State {\n";
   G.iter_vertex (fun label ->
     Buffer.add_string buffer
-    ("\    " ^ (upper_camel_case @@ Int.to_string label) ^ ",\n")
+    ("\    S" ^ (Int.to_string label) ^ ",\n")
   ) g;
   Buffer.add_string buffer "}\n"
 
 let generate_labels buffer g = 
   let labels = collect_labels g in
-  generate_derive buffer;
-  Buffer.add_string buffer "enum Label {\n";
+  generate_big_derive buffer;
+  Buffer.add_string buffer "pub enum Label {\n";
   Set.iter labels ~f:(fun label ->
     Buffer.add_string buffer
     ("\    " ^ (upper_camel_case label) ^ ",\n")
@@ -42,22 +45,22 @@ let generate_labels buffer g =
   Buffer.add_string buffer "}\n"
 
 let generate_support_types buffer = 
-  generate_derive buffer;
+  generate_big_derive buffer;
   Buffer.add_string buffer 
-  "enum Direction {\n\
+  "pub enum Direction {\n\
   \    Send,\n\
   \    Recv,\n\
    }\n\
   \n";
-  generate_derive buffer;
+  generate_big_derive buffer;
   Buffer.add_string buffer 
-  "struct Action {\n\
+  "pub struct Action {\n\
   \    dir: Direction,\n\
   \    label: Label,\n\
    }\n"
 
 let generate_monitor buffer protocol_name = 
-  generate_derive buffer;
+  generate_small_derive buffer;
   Buffer.add_string buffer 
   ("pub struct " ^ protocol_name ^ "Monitor {\n\
   \    state: State,\n\
@@ -66,9 +69,9 @@ let generate_monitor buffer protocol_name =
 let generate_transitions buffer start g protocol_name =
   Buffer.add_string buffer 
   ("impl " ^ protocol_name ^ "Monitor {\n\
-  \    pub fn new() ->  Self {\n\
+  \    pub fn new() -> Self {\n\
   \        Self {\n\
-  \            state: State::" ^ upper_camel_case @@ Int.to_string start ^ "\n\
+  \            state: State::S" ^ (Int.to_string start) ^ "\n\
   \        }\n\
   \    }\n\
   \n\
@@ -78,25 +81,26 @@ let generate_transitions buffer start g protocol_name =
   G.iter_edges_e (fun (src, a, dst) ->
     match a with
     | SendA (_, m, _) ->
-        Buffer.add_string buffer
-          (Printf.sprintf
-             "            (State::%s, Direction::Send, Label::%s) \
-              => { self.state = State::%s; true }\n"
-             (int_to_name src)
-             (upper_camel_case (LabelName.user m.label))
-             (int_to_name dst))
+      Buffer.add_string buffer
+        (Printf.sprintf
+          "            (State::S%s, Direction::Send, Label::%s) \
+            => { self.state = State::S%s; true }\n"
+          (int_to_name src)
+          (upper_camel_case (LabelName.user m.label))
+          (int_to_name dst))
     | RecvA (_, m, _) ->
-        Buffer.add_string buffer
-          (Printf.sprintf
-             "            (State::%s, Direction::Recv, Label::%s) \
-              => { self.state = State::%s; true }\n"
-             (int_to_name src)
-             (upper_camel_case (LabelName.user m.label))
-             (int_to_name dst))
+      Buffer.add_string buffer
+        (Printf.sprintf
+          "            (State::S%s, Direction::Recv, Label::%s) \
+          => { self.state = State::S%s; true }\n"
+          (int_to_name src)
+          (upper_camel_case (LabelName.user m.label))
+          (int_to_name dst))
     | Epsilon -> ()
   ) g ;
   Buffer.add_string buffer
-  "        }\n\
+  "            _ => false
+  \        }\n\
   \    }\n\
   }\n"
 

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -97,6 +97,8 @@ let payload_slice_pattern payloads =
   in
   "[" ^ String.concat ~sep:", " patterns ^ "]"
 
+let payload_constraints _ = "true"
+
 let generate_transitions buffer start g protocol_name =
   Buffer.add_string buffer 
   ("impl " ^ protocol_name ^ "Monitor {\n\
@@ -119,14 +121,15 @@ let generate_transitions buffer start g protocol_name =
         (Printf.sprintf
           "            (State::S%s, Direction::%s, Label::%s) => \
            match action.payloads.as_slice() {\n\
-           \                %s => { self.state = State::S%s; true }\n\
+           \                %s => { self.state = State::S%s; %s }\n\
            \                _ => false\n\
            \            },\n"
           (int_to_name src)
           dir
           (upper_camel_case (LabelName.user m.label))
           (payload_slice_pattern m.payload)
-          (int_to_name dst))
+          (int_to_name dst)
+          (payload_constraints m.payload))
     | Epsilon -> ()
   ) g ;
   Buffer.add_string buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -7,6 +7,8 @@ open Message
 let upper_camel_case s:string = 
   Stdlib.String.capitalize_ascii @@ Stdlib.String.lowercase_ascii s
 
+let int_to_name i = upper_camel_case @@ Int.to_string i
+
 let collect_labels g =
   let f (_, a, _) acc =
     match a with
@@ -20,11 +22,19 @@ let collect_labels g =
 let generate_derive buffer = 
   Buffer.add_string buffer "#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n"
 
+let generate_states buffer g =
+  generate_derive buffer;
+  Buffer.add_string buffer "enum State {\n";
+  G.iter_vertex (fun label ->
+    Buffer.add_string buffer
+    ("\    " ^ (upper_camel_case @@ Int.to_string label) ^ ",\n")
+  ) g;
+  Buffer.add_string buffer "}\n"
+
 let generate_labels buffer g = 
   let labels = collect_labels g in
   generate_derive buffer;
-  Buffer.add_string buffer
-  "enum Label {\n";
+  Buffer.add_string buffer "enum Label {\n";
   Set.iter labels ~f:(fun label ->
     Buffer.add_string buffer
     ("\    " ^ (upper_camel_case label) ^ ",\n")
@@ -46,17 +56,61 @@ let generate_support_types buffer =
   \    label: Label,\n\
    }\n"
 
-let generate_monitor buffer protocol = 
+let generate_monitor buffer protocol_name = 
   generate_derive buffer;
-  Buffer.add_string buffer ("pub struct " ^ protocol ^ "Monitor; \n")
+  Buffer.add_string buffer 
+  ("pub struct " ^ protocol_name ^ "Monitor {\n\
+  \    state: State,\n\
+  }\n")
+
+let generate_transitions buffer start g protocol_name =
+  Buffer.add_string buffer 
+  ("impl " ^ protocol_name ^ "Monitor {\n\
+  \    pub fn new() ->  Self {\n\
+  \        Self {\n\
+  \            state: State::" ^ upper_camel_case @@ Int.to_string start ^ "\n\
+  \        }\n\
+  \    }\n\
+  \n\
+  \    pub fn step(&mut self, action: &Action) -> bool {\n\
+  \        match (self.state, action.dir, action.label) {\n\
+  ");
+  G.iter_edges_e (fun (src, a, dst) ->
+    match a with
+    | SendA (_, m, _) ->
+        Buffer.add_string buffer
+          (Printf.sprintf
+             "            (State::%s, Direction::Send, Label::%s) \
+              => { self.state = State::%s; true }\n"
+             (int_to_name src)
+             (upper_camel_case (LabelName.user m.label))
+             (int_to_name dst))
+    | RecvA (_, m, _) ->
+        Buffer.add_string buffer
+          (Printf.sprintf
+             "            (State::%s, Direction::Recv, Label::%s) \
+              => { self.state = State::%s; true }\n"
+             (int_to_name src)
+             (upper_camel_case (LabelName.user m.label))
+             (int_to_name dst))
+    | Epsilon -> ()
+  ) g ;
+  Buffer.add_string buffer
+  "        }\n\
+  \    }\n\
+  }\n"
 
 (* let gen_code (start, (g, rec_var_info)) ~protocol =  *)
-let gen_code (_, (g,_)) ~protocol =
+let gen_code (start, (g,_)) ~protocol =
   let buffer = Buffer.create 4096 in
   let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
+  generate_states buffer g;
+  Buffer.add_string buffer "\n";
   generate_labels buffer g;
   Buffer.add_string buffer "\n";
   generate_support_types buffer;
   Buffer.add_string buffer "\n";
   generate_monitor buffer protocol_name;
+  Buffer.add_string buffer "\n";
+  generate_transitions buffer start g protocol_name;
   Buffer.contents buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -13,76 +13,63 @@ let generate_small_derive buffer =
   Buffer.add_string buffer "#[derive(Debug, Clone, PartialEq, Eq)]\n"
 
 let generate_state_enum buffer var_map g =
-  generate_small_derive buffer;
-  Buffer.add_string buffer "enum State {\n";
-  G.iter_vertex (fun state ->
-    let vars = Map.find_exn var_map state in
-    match vars with
-    | [] ->
-        Buffer.add_string buffer
-          (Printf.sprintf "    S%d,\n" state)
-    | _ ->
-        let fields =
-          List.map vars ~f:(fun (v, ty) ->
-            Printf.sprintf "%s: %s"
-              (VariableName.user v)
-              (Rustexpr.rust_type_of_payload_type ty))
-        in
-        Buffer.add_string buffer
-          (Printf.sprintf "    S%d { %s },\n" state
-             (String.concat ~sep:", " fields))
-  ) g;
+  generate_small_derive buffer ;
+  Buffer.add_string buffer "enum State {\n" ;
+  G.iter_vertex
+    (fun state ->
+      let vars = Map.find_exn var_map state in
+      match vars with
+      | [] -> Buffer.add_string buffer (Printf.sprintf "    S%d,\n" state)
+      | _ ->
+          let fields =
+            List.map vars ~f:(fun (v, ty) ->
+                Printf.sprintf "%s: %s" (VariableName.user v)
+                  (Rustexpr.rust_type_of_payload_type ty) )
+          in
+          Buffer.add_string buffer
+            (Printf.sprintf "    S%d { %s },\n" state
+               (String.concat ~sep:", " fields) ) )
+    g ;
   Buffer.add_string buffer "}\n"
 
 let generate_labels buffer g =
   let labels = collect_labels g in
-  generate_big_derive buffer;
-  Buffer.add_string buffer "pub enum Label {\n";
+  generate_big_derive buffer ;
+  Buffer.add_string buffer "pub enum Label {\n" ;
   Set.iter labels ~f:(fun label ->
-    Buffer.add_string buffer
-    ("\    " ^ (upper_camel_case label) ^ ",\n")
-  );
+      Buffer.add_string buffer ("    " ^ upper_camel_case label ^ ",\n") ) ;
   Buffer.add_string buffer "}\n"
 
 let generate_support_types buffer =
-  generate_big_derive buffer;
+  generate_big_derive buffer ;
   Buffer.add_string buffer
-  "pub enum Direction {\n\
-  \    Send,\n\
-  \    Recv,\n\
-   }\n\
-  \n";
-  generate_small_derive buffer;
+    "pub enum Direction {\n    Send,\n    Recv,\n}\n\n" ;
+  generate_small_derive buffer ;
   Buffer.add_string buffer
-  "pub enum Value {\n\
-  \    Int(i64),\n\
-  \    Bool(bool),\n\
-  \    String(String),\n\
-  \    Unit,\n\
-   }\n\
-  \n";
-  generate_small_derive buffer;
+    "pub enum Value {\n\
+    \    Int(i64),\n\
+    \    Bool(bool),\n\
+    \    String(String),\n\
+    \    Unit,\n\
+     }\n\n" ;
+  generate_small_derive buffer ;
   Buffer.add_string buffer
-  "pub struct Action {\n\
-  \    dir: Direction,\n\
-  \    label: Label,\n\
-  \    payloads: Vec<Value>,\n\
-   }\n"
+    "pub struct Action {\n\
+    \    dir: Direction,\n\
+    \    label: Label,\n\
+    \    payloads: Vec<Value>,\n\
+     }\n"
 
 let generate_monitor_struct buffer protocol_name =
-  generate_small_derive buffer;
+  generate_small_derive buffer ;
   Buffer.add_string buffer
-    (Printf.sprintf
-       "pub struct %sMonitor {\n\
-       \    state: State,\n\
-        }\n" protocol_name)
+    (Printf.sprintf "pub struct %sMonitor {\n    state: State,\n}\n"
+       protocol_name )
 
 let fmt_state_variant state fields =
   match fields with
   | [] -> Printf.sprintf "S%d" state
-  | _ ->
-      Printf.sprintf "S%d { %s }" state
-        (String.concat ~sep:", " fields)
+  | _ -> Printf.sprintf "S%d { %s }" state (String.concat ~sep:", " fields)
 
 let generate_constructor buffer start var_map rec_var_info =
   let start_vars = Map.find_exn var_map start in
@@ -90,30 +77,29 @@ let generate_constructor buffer start var_map rec_var_info =
     Option.value ~default:[] (Map.find rec_var_info start)
   in
   List.iter start_vars ~f:(fun (v, _) ->
-    let is_rec_var =
-      List.exists start_rv_info
-        ~f:(fun rv -> VariableName.equal v rv.rv_name)
-    in
-    if not is_rec_var then
-      Err.violationf ~here:[%here]
-        "Payload variable '%s' at start state has no initial value"
-        (VariableName.user v));
+      let is_rec_var =
+        List.exists start_rv_info ~f:(fun rv ->
+            VariableName.equal v rv.rv_name )
+      in
+      if not is_rec_var then
+        Err.violationf ~here:[%here]
+          "Payload variable '%s' at start state has no initial value"
+          (VariableName.user v) ) ;
   let inits =
     List.map start_vars ~f:(fun (v, _) ->
-      let rv = List.find_exn start_rv_info
-        ~f:(fun rv -> VariableName.equal v rv.rv_name)
-      in
-      Printf.sprintf "%s: %s"
-        (VariableName.user v)
-        (Rustexpr.rust_show_expr rv.rv_init_expr))
+        let rv =
+          List.find_exn start_rv_info ~f:(fun rv ->
+              VariableName.equal v rv.rv_name )
+        in
+        Printf.sprintf "%s: %s" (VariableName.user v)
+          (Rustexpr.rust_show_expr rv.rv_init_expr) )
   in
   Buffer.add_string buffer
     (Printf.sprintf
        "    pub fn new() -> Self {\n\
        \        Self { state: State::%s }\n\
        \    }\n"
-       (fmt_state_variant start inits))
-
+       (fmt_state_variant start inits) )
 
 (* Precondition: silent vars have been stripped by [rm_silent_var]. *)
 let compute_rec_var_updates rannot dst_rv_info =
@@ -121,144 +107,153 @@ let compute_rec_var_updates rannot dst_rv_info =
   let n_rec_vars = List.length dst_rv_info in
   if n_updates > n_rec_vars then
     Err.violationf ~here:[%here]
-      "More rec_expr_updates (%d) than destination rec vars (%d)"
-      n_updates n_rec_vars;
+      "More rec_expr_updates (%d) than destination rec vars (%d)" n_updates
+      n_rec_vars ;
   let paired =
-    List.zip_exn rannot.rec_expr_updates
-      (List.take dst_rv_info n_updates)
+    List.zip_exn rannot.rec_expr_updates (List.take dst_rv_info n_updates)
   in
   List.map paired ~f:(fun (e, rv) ->
-    let binding = "new_" ^ VariableName.user rv.rv_name in
-    (rv.rv_name, binding, e, rv.rv_ty))
+      let binding = "new_" ^ VariableName.user rv.rv_name in
+      (rv.rv_name, binding, e, rv.rv_ty) )
 
 let find_new_rec_vars src_vars dst_rv_info rec_var_updates =
   List.filter_map dst_rv_info ~f:(fun rv ->
-    let in_src = List.exists src_vars
-      ~f:(fun (v, _) -> VariableName.equal v rv.rv_name) in
-    let has_update = List.exists rec_var_updates
-      ~f:(fun (name, _, _, _) -> VariableName.equal name rv.rv_name) in
-    if (not in_src) && (not has_update) then
-      Some (rv.rv_name, Rustexpr.rust_show_expr rv.rv_init_expr)
-    else None)
+      let in_src =
+        List.exists src_vars ~f:(fun (v, _) ->
+            VariableName.equal v rv.rv_name )
+      in
+      let has_update =
+        List.exists rec_var_updates ~f:(fun (name, _, _, _) ->
+            VariableName.equal name rv.rv_name )
+      in
+      if (not in_src) && not has_update then
+        Some (rv.rv_name, Rustexpr.rust_show_expr rv.rv_init_expr)
+      else None )
 
 let build_dst_field_inits dst_vars rec_var_updates new_rec_vars =
   List.map dst_vars ~f:(fun (v, _) ->
-    let name = VariableName.user v in
-    let updated_binding =
-      List.find_map rec_var_updates
-        ~f:(fun (rv, binding, _, _) -> Option.some_if (VariableName.equal v rv) binding)
-    in
-    let init_expr =
-      List.find_map new_rec_vars
-        ~f:(fun (rv, expr) -> Option.some_if (VariableName.equal v rv) expr)
-    in
-    match updated_binding, init_expr with
-    | Some binding, _ -> Printf.sprintf "%s: %s" name binding
-    | None, Some expr  -> Printf.sprintf "%s: %s" name expr
-    | None, None       -> name)
+      let name = VariableName.user v in
+      let updated_binding =
+        List.find_map rec_var_updates ~f:(fun (rv, binding, _, _) ->
+            Option.some_if (VariableName.equal v rv) binding )
+      in
+      let init_expr =
+        List.find_map new_rec_vars ~f:(fun (rv, expr) ->
+            Option.some_if (VariableName.equal v rv) expr )
+      in
+      match (updated_binding, init_expr) with
+      | Some binding, _ -> Printf.sprintf "%s: %s" name binding
+      | None, Some expr -> Printf.sprintf "%s: %s" name expr
+      | None, None -> name )
 
 let generate_step_fn buffer g var_map rec_var_info =
   Buffer.add_string buffer
     "\n\
     \    pub fn step(&mut self, action: &Action) -> bool {\n\
-    \        match (self.state.clone(), &action.dir, &action.label) {\n";
-  G.iter_edges_e (fun (src, a, dst) ->
-    match a with
-    | SendA (_, m, rannot) | RecvA (_, m, rannot) ->
-        let dir = match a with SendA _ -> "Send" | RecvA _ -> "Recv" | Epsilon -> assert false in
-        let src_vars = Map.find_exn var_map src in
-        let dst_vars = Map.find_exn var_map dst in
-        let dst_rv_info = Option.value ~default:[] (Map.find rec_var_info dst) in
-        let rec_var_updates = compute_rec_var_updates rannot dst_rv_info in
-        let new_rec_vars = find_new_rec_vars src_vars dst_rv_info rec_var_updates in
-        let dst_field_inits = build_dst_field_inits dst_vars rec_var_updates new_rec_vars in
-        let src_fields = List.map src_vars ~f:(fun (v, _) -> VariableName.user v) in
-
-        (* State + direction + label *)
-        Buffer.add_string buffer
-          (Printf.sprintf
-             "            (State::%s, Direction::%s, Label::%s) =>\n"
-             (fmt_state_variant src src_fields) dir
-             (upper_camel_case (LabelName.user m.label)));
-
-        (* Payload match *)
-        Buffer.add_string buffer
-          (Printf.sprintf
-             "                match action.payloads.as_slice() {\n\
-             \                    %s => {\n"
-             (Rustexpr.rust_payload_slice_pattern m.payload));
-
-        (* Clone payload bindings from slice refs to owned values *)
-        let payload_vars = find_payload_vars m in
-        List.iter payload_vars ~f:(fun (v, _) ->
-          let name = VariableName.user v in
-          Buffer.add_string buffer
-            (Printf.sprintf "                        let %s = %s.clone();\n"
-               name name));
-
-        (* Payload constraints *)
-        Option.iter (Rustexpr.rust_payload_constraints m.payload) ~f:(fun c ->
+    \        match (self.state.clone(), &action.dir, &action.label) {\n" ;
+  G.iter_edges_e
+    (fun (src, a, dst) ->
+      match a with
+      | SendA (_, m, rannot) | RecvA (_, m, rannot) ->
+          let dir =
+            match a with
+            | SendA _ -> "Send"
+            | RecvA _ -> "Recv"
+            | Epsilon -> assert false
+          in
+          let src_vars = Map.find_exn var_map src in
+          let dst_vars = Map.find_exn var_map dst in
+          let dst_rv_info =
+            Option.value ~default:[] (Map.find rec_var_info dst)
+          in
+          let rec_var_updates = compute_rec_var_updates rannot dst_rv_info in
+          let new_rec_vars =
+            find_new_rec_vars src_vars dst_rv_info rec_var_updates
+          in
+          let dst_field_inits =
+            build_dst_field_inits dst_vars rec_var_updates new_rec_vars
+          in
+          let src_fields =
+            List.map src_vars ~f:(fun (v, _) -> VariableName.user v)
+          in
+          (* State + direction + label *)
           Buffer.add_string buffer
             (Printf.sprintf
-               "                        if !(%s) { return false; }\n" c));
-
-        (* Rec var update let-bindings *)
-        List.iter rec_var_updates ~f:(fun (_, binding, expr, _) ->
+               "            (State::%s, Direction::%s, Label::%s) =>\n"
+               (fmt_state_variant src src_fields)
+               dir
+               (upper_camel_case (LabelName.user m.label)) ) ;
+          (* Payload match *)
           Buffer.add_string buffer
-            (Printf.sprintf "                        let %s = %s;\n"
-               binding (Rustexpr.rust_show_expr expr)));
-
-        (* Rec var type constraints (on updated values only) *)
-        List.iter rec_var_updates ~f:(fun (_, binding, _, rv_ty) ->
-          match rv_ty with
-          | Expr.PTRefined (binder, _, pred) ->
-              let pred =
-                Expr.substitute ~from:binder
-                  ~replace:(Var (VariableName.of_string binding)) pred
-              in
+            (Printf.sprintf
+               "                match action.payloads.as_slice() {\n\
+               \                    %s => {\n"
+               (Rustexpr.rust_payload_slice_pattern m.payload) ) ;
+          (* Clone payload bindings from slice refs to owned values *)
+          let payload_vars = find_payload_vars m in
+          List.iter payload_vars ~f:(fun (v, _) ->
+              let name = VariableName.user v in
               Buffer.add_string buffer
                 (Printf.sprintf
-                   "                        if !(%s) { return false; }\n"
-                   (Rustexpr.rust_show_expr pred))
-          | _ -> ());
-
-        (* Transition to next state *)
-        Buffer.add_string buffer
-          (Printf.sprintf
-             "                        self.state = State::%s;\n\
-             \                        true\n\
-             \                    }\n\
-             \                    _ => false\n\
-             \                },\n"
-             (fmt_state_variant dst dst_field_inits))
-    | Epsilon -> ()
-  ) g;
-  Buffer.add_string buffer
-    "            _ => false\n\
-    \        }\n\
-    \    }\n"
+                   "                        let %s = %s.clone();\n" name name ) ) ;
+          (* Payload constraints *)
+          Option.iter (Rustexpr.rust_payload_constraints m.payload)
+            ~f:(fun c ->
+              Buffer.add_string buffer
+                (Printf.sprintf
+                   "                        if !(%s) { return false; }\n" c ) ) ;
+          (* Rec var update let-bindings *)
+          List.iter rec_var_updates ~f:(fun (_, binding, expr, _) ->
+              Buffer.add_string buffer
+                (Printf.sprintf "                        let %s = %s;\n"
+                   binding
+                   (Rustexpr.rust_show_expr expr) ) ) ;
+          (* Rec var type constraints (on updated values only) *)
+          List.iter rec_var_updates ~f:(fun (_, binding, _, rv_ty) ->
+              match rv_ty with
+              | Expr.PTRefined (binder, _, pred) ->
+                  let pred =
+                    Expr.substitute ~from:binder
+                      ~replace:(Var (VariableName.of_string binding))
+                      pred
+                  in
+                  Buffer.add_string buffer
+                    (Printf.sprintf
+                       "                        if !(%s) { return false; }\n"
+                       (Rustexpr.rust_show_expr pred) )
+              | _ -> () ) ;
+          (* Transition to next state *)
+          Buffer.add_string buffer
+            (Printf.sprintf
+               "                        self.state = State::%s;\n\
+               \                        true\n\
+               \                    }\n\
+               \                    _ => false\n\
+               \                },\n"
+               (fmt_state_variant dst dst_field_inits) )
+      | Epsilon -> () )
+    g ;
+  Buffer.add_string buffer "            _ => false\n        }\n    }\n"
 
 let generate_impl buffer start g protocol_name var_map rec_var_info =
   Buffer.add_string buffer
-    (Printf.sprintf "impl %sMonitor {\n" protocol_name);
-  generate_constructor buffer start var_map rec_var_info;
-  generate_step_fn buffer g var_map rec_var_info;
+    (Printf.sprintf "impl %sMonitor {\n" protocol_name) ;
+  generate_constructor buffer start var_map rec_var_info ;
+  generate_step_fn buffer g var_map rec_var_info ;
   Buffer.add_string buffer "}\n"
-
 
 let gen_code (start, (g, rec_var_info)) ~protocol =
   let rec_var_info = rm_silent_var rec_var_info in
   let var_map = compute_var_map start g rec_var_info in
   let protocol_name = upper_camel_case @@ ProtocolName.user protocol in
-
   let buffer = Buffer.create 4096 in
-  generate_state_enum buffer var_map g;
-  Buffer.add_string buffer "\n";
-  generate_labels buffer g;
-  Buffer.add_string buffer "\n";
-  generate_support_types buffer;
-  Buffer.add_string buffer "\n";
-  generate_monitor_struct buffer protocol_name;
-  Buffer.add_string buffer "\n";
-  generate_impl buffer start g protocol_name var_map rec_var_info;
+  generate_state_enum buffer var_map g ;
+  Buffer.add_string buffer "\n" ;
+  generate_labels buffer g ;
+  Buffer.add_string buffer "\n" ;
+  generate_support_types buffer ;
+  Buffer.add_string buffer "\n" ;
+  generate_monitor_struct buffer protocol_name ;
+  Buffer.add_string buffer "\n" ;
+  generate_impl buffer start g protocol_name var_map rec_var_info ;
   Buffer.contents buffer

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -6,14 +6,13 @@ open Message
 open Syntax
 open Rustefsm
 
-let generate_big_derive buffer =
-  Buffer.add_string buffer "#[derive(Debug, Clone, Copy, PartialEq, Eq)]\n"
-
-let generate_small_derive buffer =
-  Buffer.add_string buffer "#[derive(Debug, Clone, PartialEq, Eq)]\n"
+let generate_derive buffer ~copy =
+  let copy_str = if copy then ", Copy" else "" in
+  Buffer.add_string buffer
+    (Printf.sprintf "#[derive(Debug, Clone%s, PartialEq, Eq)]\n" copy_str)
 
 let generate_state_enum buffer var_map g =
-  generate_small_derive buffer ;
+  generate_derive ~copy:false buffer ;
   Buffer.add_string buffer "enum State {\n" ;
   G.iter_vertex
     (fun state ->
@@ -34,17 +33,17 @@ let generate_state_enum buffer var_map g =
 
 let generate_labels buffer g =
   let labels = collect_labels g in
-  generate_big_derive buffer ;
+  generate_derive ~copy:true buffer ;
   Buffer.add_string buffer "pub enum Label {\n" ;
   Set.iter labels ~f:(fun label ->
       Buffer.add_string buffer ("    " ^ upper_camel_case label ^ ",\n") ) ;
   Buffer.add_string buffer "}\n"
 
 let generate_support_types buffer =
-  generate_big_derive buffer ;
+  generate_derive ~copy:true buffer ;
   Buffer.add_string buffer
     "pub enum Direction {\n    Send,\n    Recv,\n}\n\n" ;
-  generate_small_derive buffer ;
+  generate_derive ~copy:false buffer ;
   Buffer.add_string buffer
     "pub enum Value {\n\
     \    Int(i64),\n\
@@ -52,7 +51,7 @@ let generate_support_types buffer =
     \    String(String),\n\
     \    Unit,\n\
      }\n\n" ;
-  generate_small_derive buffer ;
+  generate_derive ~copy:false buffer ;
   Buffer.add_string buffer
     "pub struct Action {\n\
     \    dir: Direction,\n\
@@ -61,7 +60,7 @@ let generate_support_types buffer =
      }\n"
 
 let generate_monitor_struct buffer protocol_name =
-  generate_small_derive buffer ;
+  generate_derive ~copy:false buffer ;
   Buffer.add_string buffer
     (Printf.sprintf "pub struct %sMonitor {\n    state: State,\n}\n"
        protocol_name )
@@ -101,7 +100,8 @@ let generate_constructor buffer start var_map rec_var_info =
        \    }\n"
        (fmt_state_variant start inits) )
 
-(* Precondition: silent vars have been stripped by [rm_silent_var]. *)
+(* Precondition: silent vars have been stripped by [rm_silent_var]. Also:
+   rec_expr_updates and dst_rv_info are paired positionally *)
 let compute_rec_var_updates rannot dst_rv_info =
   let n_updates = List.length rannot.rec_expr_updates in
   let n_rec_vars = List.length dst_rv_info in

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -217,7 +217,7 @@ let generate_step_fn buffer g var_map rec_var_info =
   Buffer.add_string buffer
     "\n\
     \    pub fn step(&mut self, action: &Action) -> bool {\n\
-    \        match (&self.state, &action.dir, &action.label) {\n";
+    \        match (self.state.clone(), &action.dir, &action.label) {\n";
   G.iter_edges_e (fun (src, a, dst) ->
     match a with
     | SendA (_, m, rannot) | RecvA (_, m, rannot) ->
@@ -250,6 +250,14 @@ let generate_step_fn buffer g var_map rec_var_info =
              "                match action.payloads.as_slice() {\n\
              \                    %s => {\n"
              (Rustexpr.payload_slice_pattern m.payload));
+
+        (* Clone payload bindings from slice refs to owned values *)
+        let payload_vars = find_payload_vars m in
+        List.iter payload_vars ~f:(fun (v, _) ->
+          let name = VariableName.user v in
+          Buffer.add_string buffer
+            (Printf.sprintf "                        let %s = %s.clone();\n"
+               name name));
 
         (* Payload constraints *)
         Option.iter (Rustexpr.payload_constraints m.payload) ~f:(fun c ->

--- a/lib/codegen/rust/rustcodegen.ml
+++ b/lib/codegen/rust/rustcodegen.ml
@@ -9,6 +9,43 @@ let upper_camel_case s:string =
 
 let int_to_name i = upper_camel_case @@ Int.to_string i
 
+let find_payload_vars m =
+  List.filter_map m.payload ~f:(function
+    | PValue (Some v, ty) -> Some (v, ty)
+    | _ -> None)
+
+let append_var lst ((v, _) as entry) =
+  if List.exists lst ~f:(fun (v_, _) -> VariableName.equal v v_) then lst
+  else lst @ [entry]
+
+(* Walk the EFSM graph from [start], accumulating rec vars and named payload
+   vars along each path. Each state is visited at most once: when choice
+   branches merge into a single state, session-type merging guarantees
+   identical variable scopes on every path, so the first visit suffices. *)
+let compute_var_map start g rec_var_info =
+  let rec aux acc (curr_st, vars) =
+    match Map.find acc curr_st with
+    | Some _ -> acc
+    | None ->
+        let rec_vars =
+          Option.value ~default:[] (Map.find rec_var_info curr_st)
+          |> List.map ~f:(fun (_, (rv : Gtype.rec_var)) -> (rv.rv_name, rv.rv_ty))
+        in
+        let vars = List.fold ~f:append_var ~init:vars rec_vars in
+        let acc = Map.set acc ~key:curr_st ~data:vars in
+        G.fold_succ_e (fun (_, action, next_st) acc ->
+          match action with
+          | SendA (_, m, _) | RecvA (_, m, _) ->
+              let payload_vars = find_payload_vars m in
+              let vars = List.fold ~f:append_var ~init:vars payload_vars in
+              aux acc (next_st, vars)
+          | Epsilon ->
+              Err.violation ~here:[%here]
+                "Epsilon transitions should not appear in EFSM outputs"
+        ) g curr_st acc
+  in
+  aux (Map.empty (module Int)) (start, [])
+
 let collect_labels g =
   let f (_, a, _) acc =
     match a with

--- a/lib/codegen/rust/rustcodegen.mli
+++ b/lib/codegen/rust/rustcodegen.mli
@@ -1,0 +1,5 @@
+(** Generate Rust monitor code from EFSM *)
+
+open Names
+
+val gen_code : Efsm.state * Efsm.t -> protocol:ProtocolName.t -> string

--- a/lib/codegen/rust/rustefsm.ml
+++ b/lib/codegen/rust/rustefsm.ml
@@ -4,13 +4,13 @@ open Names
 open Message
 open Efsm
 
-let upper_camel_case s:string =
+let upper_camel_case s : string =
   Stdlib.String.capitalize_ascii @@ Stdlib.String.lowercase_ascii s
 
 let find_payload_vars m =
   List.filter_map m.payload ~f:(function
     | PValue (Some v, ty) -> Some (v, ty)
-    | _ -> None)
+    | _ -> None )
 
 let append_var lst ((v, _) as entry) =
   if List.exists lst ~f:(fun (v_, _) -> VariableName.equal v v_) then lst
@@ -18,12 +18,13 @@ let append_var lst ((v, _) as entry) =
 
 let rm_silent_var rec_var_info =
   Map.map rec_var_info ~f:(fun data ->
-    List.map data ~f:(fun (is_silent, rv) ->
-      if is_silent then
-        Err.unimpl ~here:[%here]
-          (Printf.sprintf "Rust codegen for silent recursion variable '%s'"
-            (VariableName.user rv.rv_name))
-      else rv))
+      List.map data ~f:(fun (is_silent, rv) ->
+          if is_silent then
+            Err.unimpl ~here:[%here]
+              (Printf.sprintf
+                 "Rust codegen for silent recursion variable '%s'"
+                 (VariableName.user rv.rv_name) )
+          else rv ) )
 
 (* Walk the EFSM graph from [start], accumulating rec vars and named payload
    vars along each path. Each state is visited at most once: when choice
@@ -40,16 +41,17 @@ let compute_var_map start g rec_var_info =
         in
         let vars = List.fold ~f:append_var ~init:vars rec_vars in
         let acc = Map.set acc ~key:curr_st ~data:vars in
-        G.fold_succ_e (fun (_, action, next_st) acc ->
-          match action with
-          | SendA (_, m, _) | RecvA (_, m, _) ->
-              let payload_vars = find_payload_vars m in
-              let vars = List.fold ~f:append_var ~init:vars payload_vars in
-              aux acc (next_st, vars)
-          | Epsilon ->
-              Err.violation ~here:[%here]
-                "Epsilon transitions should not appear in EFSM outputs"
-        ) g curr_st acc
+        G.fold_succ_e
+          (fun (_, action, next_st) acc ->
+            match action with
+            | SendA (_, m, _) | RecvA (_, m, _) ->
+                let payload_vars = find_payload_vars m in
+                let vars = List.fold ~f:append_var ~init:vars payload_vars in
+                aux acc (next_st, vars)
+            | Epsilon ->
+                Err.violation ~here:[%here]
+                  "Epsilon transitions should not appear in EFSM outputs" )
+          g curr_st acc
   in
   aux (Map.empty (module Int)) (start, [])
 

--- a/lib/codegen/rust/rustefsm.ml
+++ b/lib/codegen/rust/rustefsm.ml
@@ -1,0 +1,63 @@
+open! Base
+open Gtype
+open Names
+open Message
+open Efsm
+
+let upper_camel_case s:string =
+  Stdlib.String.capitalize_ascii @@ Stdlib.String.lowercase_ascii s
+
+let find_payload_vars m =
+  List.filter_map m.payload ~f:(function
+    | PValue (Some v, ty) -> Some (v, ty)
+    | _ -> None)
+
+let append_var lst ((v, _) as entry) =
+  if List.exists lst ~f:(fun (v_, _) -> VariableName.equal v v_) then lst
+  else lst @ [entry]
+
+let rm_silent_var rec_var_info =
+  Map.map rec_var_info ~f:(fun data ->
+    List.map data ~f:(fun (is_silent, rv) ->
+      if is_silent then
+        Err.unimpl ~here:[%here]
+          (Printf.sprintf "Rust codegen for silent recursion variable '%s'"
+            (VariableName.user rv.rv_name))
+      else rv))
+
+(* Walk the EFSM graph from [start], accumulating rec vars and named payload
+   vars along each path. Each state is visited at most once: when choice
+   branches merge into a single state, session-type merging guarantees
+   identical variable scopes on every path, so the first visit suffices. *)
+let compute_var_map start g rec_var_info =
+  let rec aux acc (curr_st, vars) =
+    match Map.find acc curr_st with
+    | Some _ -> acc
+    | None ->
+        let rec_vars =
+          Option.value ~default:[] (Map.find rec_var_info curr_st)
+          |> List.map ~f:(fun rv -> (rv.rv_name, rv.rv_ty))
+        in
+        let vars = List.fold ~f:append_var ~init:vars rec_vars in
+        let acc = Map.set acc ~key:curr_st ~data:vars in
+        G.fold_succ_e (fun (_, action, next_st) acc ->
+          match action with
+          | SendA (_, m, _) | RecvA (_, m, _) ->
+              let payload_vars = find_payload_vars m in
+              let vars = List.fold ~f:append_var ~init:vars payload_vars in
+              aux acc (next_st, vars)
+          | Epsilon ->
+              Err.violation ~here:[%here]
+                "Epsilon transitions should not appear in EFSM outputs"
+        ) g curr_st acc
+  in
+  aux (Map.empty (module Int)) (start, [])
+
+let collect_labels g =
+  let f (_, a, _) acc =
+    match a with
+    | SendA (_, m, _) | RecvA (_, m, _) ->
+        Set.add acc (LabelName.user m.label)
+    | Epsilon -> acc
+  in
+  G.fold_edges_e f g (Set.empty (module String))

--- a/lib/codegen/rust/rustefsm.ml
+++ b/lib/codegen/rust/rustefsm.ml
@@ -4,8 +4,7 @@ open Names
 open Message
 open Efsm
 
-let upper_camel_case s : string =
-  Stdlib.String.capitalize_ascii @@ Stdlib.String.lowercase_ascii s
+let upper_camel_case s = Stdlib.String.capitalize_ascii s
 
 let find_payload_vars m =
   List.filter_map m.payload ~f:(function

--- a/lib/codegen/rust/rustefsm.mli
+++ b/lib/codegen/rust/rustefsm.mli
@@ -8,19 +8,17 @@ open Efsm
 
 val upper_camel_case : string -> string
 
-val find_payload_vars :
-  message -> (VariableName.t * Expr.payload_type) list
+val find_payload_vars : message -> (VariableName.t * Expr.payload_type) list
 
-val rm_silent_var :
-  rec_var_info -> rec_var list Map.M(Int).t
-(** Strip the [bool] silent-flag from [rec_var_info], raising on any silent var.
-    Must be called before [compute_var_map]. *)
+val rm_silent_var : rec_var_info -> rec_var list Map.M(Int).t
+(** Strip the [bool] silent-flag from [rec_var_info], raising on any silent
+    var. Must be called before [compute_var_map]. *)
 
 val compute_var_map :
-  state ->
-  G.t ->
-  rec_var list Map.M(Int).t ->
-  (VariableName.t * Expr.payload_type) list Map.M(Int).t
+     state
+  -> G.t
+  -> rec_var list Map.M(Int).t
+  -> (VariableName.t * Expr.payload_type) list Map.M(Int).t
 (** Walk the EFSM from [start], returning the set of variables in scope at
     each reachable state. Takes the output of [rm_silent_var], not raw
     [rec_var_info]. *)

--- a/lib/codegen/rust/rustefsm.mli
+++ b/lib/codegen/rust/rustefsm.mli
@@ -1,0 +1,28 @@
+(** EFSM analysis utilities for Rust monitor code generation *)
+
+open! Base
+open Names
+open Message
+open Gtype
+open Efsm
+
+val upper_camel_case : string -> string
+
+val find_payload_vars :
+  message -> (VariableName.t * Expr.payload_type) list
+
+val rm_silent_var :
+  rec_var_info -> rec_var list Map.M(Int).t
+(** Strip the [bool] silent-flag from [rec_var_info], raising on any silent var.
+    Must be called before [compute_var_map]. *)
+
+val compute_var_map :
+  state ->
+  G.t ->
+  rec_var list Map.M(Int).t ->
+  (VariableName.t * Expr.payload_type) list Map.M(Int).t
+(** Walk the EFSM from [start], returning the set of variables in scope at
+    each reachable state. Takes the output of [rm_silent_var], not raw
+    [rec_var_info]. *)
+
+val collect_labels : G.t -> Set.M(String).t

--- a/lib/codegen/rust/rustexpr.ml
+++ b/lib/codegen/rust/rustexpr.ml
@@ -31,8 +31,7 @@ let rec rust_type_of_payload_type = function
   | Expr.PTAbstract n ->
       Err.unimpl ~here:[%here]
         (Printf.sprintf
-           "abstract payload type '%s' is not supported in Rust codegen; \
-            use bool, int, string or unit"
+           "in Rust codegen use bool, int, string or unit, abstract payload type '%s'"
            (PayloadTypeName.user n))
 
 let rust_keywords = Set.of_list (module String)
@@ -41,11 +40,11 @@ let rust_keywords = Set.of_list (module String)
   ; "move"; "mut"; "pub"; "ref"; "return"; "self"; "Self"; "static"; "struct"
   ; "super"; "trait"; "true"; "type"; "unsafe"; "use"; "where"; "while" ]
 
-let validate_rust_ident v =
+let rust_validate_identifier v =
   if Set.mem rust_keywords (VariableName.user v) then
     Err.uerr (Err.RustKeywordConflict v)
 
-let rec rust_value_pattern name_opt = function
+let rec rust_value_pattern_of_payload name_opt = function
   | Expr.PTInt ->
       let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
       Printf.sprintf "Value::Int(%s)" b
@@ -56,25 +55,24 @@ let rec rust_value_pattern name_opt = function
       let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
       Printf.sprintf "Value::String(%s)" b
   | Expr.PTUnit -> "Value::Unit"
-  | Expr.PTRefined (_, t, _) -> rust_value_pattern name_opt t
+  | Expr.PTRefined (_, t, _) -> rust_value_pattern_of_payload name_opt t
   | Expr.PTAbstract n ->
       Err.unimpl ~here:[%here]
         (Printf.sprintf
-           "abstract payload type '%s' is not supported in Rust codegen; \
-            use bool, int, string or unit"
+           "in Rust codegen use bool, int, string or unit, abstract payload type '%s'"
            (PayloadTypeName.user n))
 
-let payload_slice_pattern payloads =
+let rust_payload_slice_pattern payloads =
   let patterns =
     List.filter_map payloads ~f:(function
       | PValue (name_opt, ty) ->
-          Option.iter name_opt ~f:validate_rust_ident;
-          Some (rust_value_pattern name_opt ty)
+          Option.iter name_opt ~f:rust_validate_identifier;
+          Some (rust_value_pattern_of_payload name_opt ty)
       | PDelegate _ -> None)
   in
   "[" ^ String.concat ~sep:", " patterns ^ "]"
 
-let payload_constraints payloads =
+let rust_payload_constraints payloads =
   let preds =
     List.filter_map payloads ~f:(function
       | PValue (Some _, Expr.PTRefined (_, _, pred)) ->

--- a/lib/codegen/rust/rustexpr.ml
+++ b/lib/codegen/rust/rustexpr.ml
@@ -1,0 +1,64 @@
+open! Base
+open Names
+open Syntax.Exprs
+
+let rust_show_binop = function
+  | Add -> "+" | Minus -> "-"
+  | Eq -> "==" | Neq -> "!="
+  | Lt -> "<" | Gt -> ">"
+  | Leq -> "<=" | Geq -> ">="
+  | And -> "&&" | Or -> "||"
+
+let rec rust_show_expr = function
+  | Var v -> VariableName.user v
+  | Int i -> Int.to_string i
+  | Bool b -> if b then "true" else "false"
+  | String s -> "\"" ^ s ^ "\""
+  | Binop (op, l, r) ->
+      Printf.sprintf "(%s) %s (%s)"
+        (rust_show_expr l) (rust_show_binop op) (rust_show_expr r)
+  | Unop (Neg, e) -> Printf.sprintf "-(%s)" (rust_show_expr e)
+  | Unop (Not, e) -> Printf.sprintf "!(%s)" (rust_show_expr e)
+  | Unop (StrLen, e) -> Printf.sprintf "(%s).len() as i64" (rust_show_expr e)
+
+let rust_keywords = Set.of_list (module String)
+  [ "as"; "break"; "const"; "continue"; "crate"; "else"; "enum"; "extern"
+  ; "false"; "fn"; "for"; "if"; "impl"; "in"; "let"; "loop"; "match"; "mod"
+  ; "move"; "mut"; "pub"; "ref"; "return"; "self"; "Self"; "static"; "struct"
+  ; "super"; "trait"; "true"; "type"; "unsafe"; "use"; "where"; "while" ]
+
+let validate_rust_ident v =
+  if Set.mem rust_keywords (VariableName.user v) then
+    Err.uerr (Err.RustKeywordConflict v)
+
+let rec rust_value_pattern name_opt = function
+  | Expr.PTInt ->
+      let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
+      Printf.sprintf "Value::Int(%s)" b
+  | Expr.PTBool ->
+      let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
+      Printf.sprintf "Value::Bool(%s)" b
+  | Expr.PTString ->
+      let b = Option.value_map name_opt ~default:"_" ~f:VariableName.user in
+      Printf.sprintf "Value::String(%s)" b
+  | Expr.PTUnit -> "Value::Unit"
+  | Expr.PTRefined (_, t, _) -> rust_value_pattern name_opt t
+  | Expr.PTAbstract n ->
+      Err.unimpl ~here:[%here]
+        (Printf.sprintf
+           "abstract payload type '%s' is not supported in Rust codegen; \
+            use bool, int, string or unit"
+           (PayloadTypeName.user n))
+
+let payload_slice_pattern payloads =
+  let open Message in
+  let patterns =
+    List.filter_map payloads ~f:(function
+      | PValue (name_opt, ty) ->
+          Option.iter name_opt ~f:validate_rust_ident;
+          Some (rust_value_pattern name_opt ty)
+      | PDelegate _ -> None)
+  in
+  "[" ^ String.concat ~sep:", " patterns ^ "]"
+
+let payload_constraints _ = "true"

--- a/lib/codegen/rust/rustexpr.ml
+++ b/lib/codegen/rust/rustexpr.ml
@@ -80,7 +80,6 @@ let rust_keywords =
     ; "while"
     ; "state"
     ; "action"
-    ; "self"
     ; "label"
     ; "dir" ]
 

--- a/lib/codegen/rust/rustexpr.ml
+++ b/lib/codegen/rust/rustexpr.ml
@@ -82,5 +82,5 @@ let payload_constraints payloads =
       | _ -> None)
   in
   match preds with
-  | [] -> "true"
-  | _ -> String.concat ~sep:" && " preds
+  | [] -> None
+  | _ -> Some (String.concat ~sep:" && " preds)

--- a/lib/codegen/rust/rustexpr.ml
+++ b/lib/codegen/rust/rustexpr.ml
@@ -1,6 +1,7 @@
 open! Base
 open Names
 open Syntax.Exprs
+open Message
 
 let rust_show_binop = function
   | Add -> "+" | Minus -> "-"
@@ -64,7 +65,6 @@ let rec rust_value_pattern name_opt = function
            (PayloadTypeName.user n))
 
 let payload_slice_pattern payloads =
-  let open Message in
   let patterns =
     List.filter_map payloads ~f:(function
       | PValue (name_opt, ty) ->
@@ -74,4 +74,13 @@ let payload_slice_pattern payloads =
   in
   "[" ^ String.concat ~sep:", " patterns ^ "]"
 
-let payload_constraints _ = "true"
+let payload_constraints payloads =
+  let preds =
+    List.filter_map payloads ~f:(function
+      | PValue (Some _, Expr.PTRefined (_, _, pred)) ->
+          Some (rust_show_expr pred)
+      | _ -> None)
+  in
+  match preds with
+  | [] -> "true"
+  | _ -> String.concat ~sep:" && " preds

--- a/lib/codegen/rust/rustexpr.ml
+++ b/lib/codegen/rust/rustexpr.ml
@@ -21,6 +21,19 @@ let rec rust_show_expr = function
   | Unop (Not, e) -> Printf.sprintf "!(%s)" (rust_show_expr e)
   | Unop (StrLen, e) -> Printf.sprintf "(%s).len() as i64" (rust_show_expr e)
 
+let rec rust_type_of_payload_type = function
+  | Expr.PTInt -> "i64"
+  | Expr.PTBool -> "bool"
+  | Expr.PTString -> "String"
+  | Expr.PTUnit -> "()"
+  | Expr.PTRefined (_, t, _) -> rust_type_of_payload_type t
+  | Expr.PTAbstract n ->
+      Err.unimpl ~here:[%here]
+        (Printf.sprintf
+           "abstract payload type '%s' is not supported in Rust codegen; \
+            use bool, int, string or unit"
+           (PayloadTypeName.user n))
+
 let rust_keywords = Set.of_list (module String)
   [ "as"; "break"; "const"; "continue"; "crate"; "else"; "enum"; "extern"
   ; "false"; "fn"; "for"; "if"; "impl"; "in"; "let"; "loop"; "match"; "mod"

--- a/lib/codegen/rust/rustexpr.ml
+++ b/lib/codegen/rust/rustexpr.ml
@@ -4,11 +4,16 @@ open Syntax.Exprs
 open Message
 
 let rust_show_binop = function
-  | Add -> "+" | Minus -> "-"
-  | Eq -> "==" | Neq -> "!="
-  | Lt -> "<" | Gt -> ">"
-  | Leq -> "<=" | Geq -> ">="
-  | And -> "&&" | Or -> "||"
+  | Add -> "+"
+  | Minus -> "-"
+  | Eq -> "=="
+  | Neq -> "!="
+  | Lt -> "<"
+  | Gt -> ">"
+  | Leq -> "<="
+  | Geq -> ">="
+  | And -> "&&"
+  | Or -> "||"
 
 let rec rust_show_expr = function
   | Var v -> VariableName.user v
@@ -16,8 +21,8 @@ let rec rust_show_expr = function
   | Bool b -> if b then "true" else "false"
   | String s -> "\"" ^ s ^ "\""
   | Binop (op, l, r) ->
-      Printf.sprintf "(%s) %s (%s)"
-        (rust_show_expr l) (rust_show_binop op) (rust_show_expr r)
+      Printf.sprintf "(%s) %s (%s)" (rust_show_expr l) (rust_show_binop op)
+        (rust_show_expr r)
   | Unop (Neg, e) -> Printf.sprintf "-(%s)" (rust_show_expr e)
   | Unop (Not, e) -> Printf.sprintf "!(%s)" (rust_show_expr e)
   | Unop (StrLen, e) -> Printf.sprintf "(%s).len() as i64" (rust_show_expr e)
@@ -31,14 +36,48 @@ let rec rust_type_of_payload_type = function
   | Expr.PTAbstract n ->
       Err.unimpl ~here:[%here]
         (Printf.sprintf
-           "in Rust codegen use bool, int, string or unit, abstract payload type '%s'"
-           (PayloadTypeName.user n))
+           "in Rust codegen use bool, int, string or unit, abstract payload \
+            type '%s'"
+           (PayloadTypeName.user n) )
 
-let rust_keywords = Set.of_list (module String)
-  [ "as"; "break"; "const"; "continue"; "crate"; "else"; "enum"; "extern"
-  ; "false"; "fn"; "for"; "if"; "impl"; "in"; "let"; "loop"; "match"; "mod"
-  ; "move"; "mut"; "pub"; "ref"; "return"; "self"; "Self"; "static"; "struct"
-  ; "super"; "trait"; "true"; "type"; "unsafe"; "use"; "where"; "while" ]
+let rust_keywords =
+  Set.of_list
+    (module String)
+    [ "as"
+    ; "break"
+    ; "const"
+    ; "continue"
+    ; "crate"
+    ; "else"
+    ; "enum"
+    ; "extern"
+    ; "false"
+    ; "fn"
+    ; "for"
+    ; "if"
+    ; "impl"
+    ; "in"
+    ; "let"
+    ; "loop"
+    ; "match"
+    ; "mod"
+    ; "move"
+    ; "mut"
+    ; "pub"
+    ; "ref"
+    ; "return"
+    ; "self"
+    ; "Self"
+    ; "static"
+    ; "struct"
+    ; "super"
+    ; "trait"
+    ; "true"
+    ; "type"
+    ; "unsafe"
+    ; "use"
+    ; "where"
+    ; "while" ]
 
 let rust_validate_identifier v =
   if Set.mem rust_keywords (VariableName.user v) then
@@ -59,16 +98,17 @@ let rec rust_value_pattern_of_payload name_opt = function
   | Expr.PTAbstract n ->
       Err.unimpl ~here:[%here]
         (Printf.sprintf
-           "in Rust codegen use bool, int, string or unit, abstract payload type '%s'"
-           (PayloadTypeName.user n))
+           "in Rust codegen use bool, int, string or unit, abstract payload \
+            type '%s'"
+           (PayloadTypeName.user n) )
 
 let rust_payload_slice_pattern payloads =
   let patterns =
     List.filter_map payloads ~f:(function
       | PValue (name_opt, ty) ->
-          Option.iter name_opt ~f:rust_validate_identifier;
+          Option.iter name_opt ~f:rust_validate_identifier ;
           Some (rust_value_pattern_of_payload name_opt ty)
-      | PDelegate _ -> None)
+      | PDelegate _ -> None )
   in
   "[" ^ String.concat ~sep:", " patterns ^ "]"
 
@@ -77,8 +117,6 @@ let rust_payload_constraints payloads =
     List.filter_map payloads ~f:(function
       | PValue (Some _, Expr.PTRefined (_, _, pred)) ->
           Some (rust_show_expr pred)
-      | _ -> None)
+      | _ -> None )
   in
-  match preds with
-  | [] -> None
-  | _ -> Some (String.concat ~sep:" && " preds)
+  match preds with [] -> None | _ -> Some (String.concat ~sep:" && " preds)

--- a/lib/codegen/rust/rustexpr.ml
+++ b/lib/codegen/rust/rustexpr.ml
@@ -77,10 +77,16 @@ let rust_keywords =
     ; "unsafe"
     ; "use"
     ; "where"
-    ; "while" ]
+    ; "while"
+    ; "state"
+    ; "action"
+    ; "self"
+    ; "label"
+    ; "dir" ]
 
 let rust_validate_identifier v =
-  if Set.mem rust_keywords (VariableName.user v) then
+  let name = VariableName.user v in
+  if Set.mem rust_keywords name || String.is_prefix name ~prefix:"new_" then
     Err.uerr (Err.RustKeywordConflict v)
 
 let rec rust_value_pattern_of_payload name_opt = function
@@ -108,7 +114,12 @@ let rust_payload_slice_pattern payloads =
       | PValue (name_opt, ty) ->
           Option.iter name_opt ~f:rust_validate_identifier ;
           Some (rust_value_pattern_of_payload name_opt ty)
-      | PDelegate _ -> None )
+      | PDelegate (protocol, role) ->
+          Err.unimpl ~here:[%here]
+            (Printf.sprintf
+               "in Rust codegen, delegation to another protocol'%s'@'%s'"
+               (ProtocolName.user protocol)
+               (RoleName.user role) ) )
   in
   "[" ^ String.concat ~sep:", " patterns ^ "]"
 

--- a/lib/codegen/rust/rustexpr.mli
+++ b/lib/codegen/rust/rustexpr.mli
@@ -12,12 +12,13 @@ val rust_type_of_payload_type : Expr.payload_type -> string
 val rust_validate_identifier : VariableName.t -> unit
 (** Raise if the variable name clashes with a Rust keyword *)
 
-val rust_value_pattern_of_payload : VariableName.t option -> Expr.payload_type -> string
+val rust_value_pattern_of_payload :
+  VariableName.t option -> Expr.payload_type -> string
 (** Build a Rust pattern for matching a Value enum variant *)
 
 val rust_payload_slice_pattern : payload list -> string
 (** Build a Rust slice pattern for a message's payload list *)
 
 val rust_payload_constraints : payload list -> string option
-(** Extract refinement predicates from payloads, conjoined with &&.
-    Returns [None] when no payloads carry refinements. *)
+(** Extract refinement predicates from payloads, conjoined with &&. Returns
+    [None] when no payloads carry refinements. *)

--- a/lib/codegen/rust/rustexpr.mli
+++ b/lib/codegen/rust/rustexpr.mli
@@ -9,15 +9,15 @@ val rust_show_expr : Expr.t -> string
 val rust_type_of_payload_type : Expr.payload_type -> string
 (** Map a payload type to its Rust type name, stripping refinements *)
 
-val validate_rust_ident : VariableName.t -> unit
+val rust_validate_identifier : VariableName.t -> unit
 (** Raise if the variable name clashes with a Rust keyword *)
 
-val rust_value_pattern : VariableName.t option -> Expr.payload_type -> string
+val rust_value_pattern_of_payload : VariableName.t option -> Expr.payload_type -> string
 (** Build a Rust pattern for matching a Value enum variant *)
 
-val payload_slice_pattern : payload list -> string
+val rust_payload_slice_pattern : payload list -> string
 (** Build a Rust slice pattern for a message's payload list *)
 
-val payload_constraints : payload list -> string option
+val rust_payload_constraints : payload list -> string option
 (** Extract refinement predicates from payloads, conjoined with &&.
     Returns [None] when no payloads carry refinements. *)

--- a/lib/codegen/rust/rustexpr.mli
+++ b/lib/codegen/rust/rustexpr.mli
@@ -1,0 +1,19 @@
+(** Compile nuscr expressions and types to Rust syntax fragments *)
+
+open Names
+open Message
+
+val rust_show_expr : Expr.t -> string
+(** Compile an expression AST to a Rust expression string *)
+
+val validate_rust_ident : VariableName.t -> unit
+(** Raise if the variable name clashes with a Rust keyword *)
+
+val rust_value_pattern : VariableName.t option -> Expr.payload_type -> string
+(** Build a Rust pattern for matching a Value enum variant *)
+
+val payload_slice_pattern : payload list -> string
+(** Build a Rust slice pattern for a message's payload list *)
+
+val payload_constraints : payload list -> string
+(** Extract refinement predicates from payloads, conjoined with && *)

--- a/lib/codegen/rust/rustexpr.mli
+++ b/lib/codegen/rust/rustexpr.mli
@@ -18,5 +18,6 @@ val rust_value_pattern : VariableName.t option -> Expr.payload_type -> string
 val payload_slice_pattern : payload list -> string
 (** Build a Rust slice pattern for a message's payload list *)
 
-val payload_constraints : payload list -> string
-(** Extract refinement predicates from payloads, conjoined with && *)
+val payload_constraints : payload list -> string option
+(** Extract refinement predicates from payloads, conjoined with &&.
+    Returns [None] when no payloads carry refinements. *)

--- a/lib/codegen/rust/rustexpr.mli
+++ b/lib/codegen/rust/rustexpr.mli
@@ -6,6 +6,9 @@ open Message
 val rust_show_expr : Expr.t -> string
 (** Compile an expression AST to a Rust expression string *)
 
+val rust_type_of_payload_type : Expr.payload_type -> string
+(** Map a payload type to its Rust type name, stripping refinements *)
+
 val validate_rust_ident : VariableName.t -> unit
 (** Raise if the variable name clashes with a Rust keyword *)
 

--- a/lib/nuscrlib.ml
+++ b/lib/nuscrlib.ml
@@ -193,6 +193,11 @@ module Toplevel = struct
     let lt = project_role ast ~protocol ~role in
     let efsm = Efsm.of_local_type lt in
     Fstarcodegen.gen_code efsm
+
+  let generate_rust_monitor_code ast ~protocol ~role = 
+    let lt = project_role ast ~protocol ~role in
+    let efsm = Efsm.of_local_type lt in
+    Rustcodegen.gen_code efsm ~protocol
 end
 
 include Toplevel

--- a/lib/nuscrlib.mli
+++ b/lib/nuscrlib.mli
@@ -109,6 +109,9 @@ val generate_fstar_code :
   scr_module -> protocol:ProtocolName.t -> role:RoleName.t -> string
 (** Generate F* code, with support for refinement types *)
 
+val generate_rust_monitor_code :
+    scr_module -> protocol:ProtocolName.t -> role:RoleName.t -> string
+
 module Pragma = Pragma
 module Expr = Expr
 module Gtype = Gtype

--- a/lib/utils/err.ml
+++ b/lib/utils/err.ml
@@ -42,6 +42,7 @@ type user_error =
   | UnsatisfiableRefinement (* TODO: Extra Message for error reporting *)
   | StuckRefinement (* TODO: Extra Message for error reporting *)
   | UnguardedTypeVariable of TypeVariableName.t
+  | RustKeywordConflict of VariableName.t
 [@@deriving sexp_of]
 
 (** UserError is a user error and should be reported back so it can be fixed
@@ -140,6 +141,9 @@ let show_user_error = function
       sprintf "Unguarded type variable %s at %s"
         (TypeVariableName.user tv)
         (Loc.show (TypeVariableName.where tv))
+  | RustKeywordConflict v ->
+      sprintf "Payload variable '%s' is a Rust keyword; rename it in the protocol"
+        (VariableName.user v)
 
 let unimpl ~here desc = UnImplemented (desc, here) |> raise
 

--- a/lib/utils/err.mli
+++ b/lib/utils/err.mli
@@ -34,6 +34,7 @@ type user_error =
   | UnsatisfiableRefinement (* TODO: Extra Message for error reporting *)
   | StuckRefinement (* TODO: Extra Message for error reporting *)
   | UnguardedTypeVariable of TypeVariableName.t
+  | RustKeywordConflict of VariableName.t
 [@@deriving sexp_of]
 
 (** UserError is a user error and should be reported back so it can be fixed

--- a/test/cram-tests/codegen/rust-codegen-silent-var.t/SilentCounter.nuscr
+++ b/test/cram-tests/codegen/rust-codegen-silent-var.t/SilentCounter.nuscr
@@ -1,0 +1,14 @@
+(*# RefinementTypes #*)
+
+global protocol SilentCounter(role A, role B) {
+  rec loop [counter<B>: (counter: int{counter < 100}) = 0] {
+    choice at A {
+      inc(x: int{x > 0}) from A to B;
+      ack(r: int{r = counter + x}) from B to A;
+      continue loop [r];
+    } or {
+      done() from A to B;
+      done() from B to A;
+    }
+  }
+}

--- a/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
+++ b/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
@@ -2,5 +2,5 @@ Rust codegen for role with silent recursion variable should report UnImplemented
   $ nuscr --gencode-rust=A@SilentCounter SilentCounter.nuscr
   nuscr: I'm sorry, it is unfortunate Rust codegen for silent recursion
          variable 'counter' is not implemented (raised at
-         lib/codegen/rust/rustcodegen.ml: line 25)
+         lib/codegen/rust/rustefsm.ml: line 23)
   [124]

--- a/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
+++ b/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
@@ -2,5 +2,5 @@ Rust codegen for role with silent recursion variable should report UnImplemented
   $ nuscr --gencode-rust=A@SilentCounter SilentCounter.nuscr
   nuscr: I'm sorry, it is unfortunate Rust codegen for silent recursion
          variable 'counter' is not implemented (raised at
-         lib/codegen/rust/rustcodegen.ml: line 316)
+         lib/codegen/rust/rustcodegen.ml: line 25)
   [124]

--- a/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
+++ b/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
@@ -2,5 +2,5 @@ Rust codegen for role with silent recursion variable should report UnImplemented
   $ nuscr --gencode-rust=A@SilentCounter SilentCounter.nuscr
   nuscr: I'm sorry, it is unfortunate Rust codegen for silent recursion
          variable 'counter' is not implemented (raised at
-         lib/codegen/rust/rustcodegen.ml: line 182)
+         lib/codegen/rust/rustcodegen.ml: line 316)
   [124]

--- a/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
+++ b/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
@@ -1,6 +1,4 @@
 Rust codegen for role with silent recursion variable should report UnImplemented
   $ nuscr --gencode-rust=A@SilentCounter SilentCounter.nuscr
-  nuscr: I'm sorry, it is unfortunate Rust codegen for silent recursion
-         variable 'counter' is not implemented (raised at
-         lib/codegen/rust/rustefsm.ml: line 23)
+  nuscr: I'm sorry, it is unfortunate Rust codegen for silent recursion variable 'counter' is not implemented (raised at lib/codegen/rust/rustefsm.ml: line 22)
   [124]

--- a/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
+++ b/test/cram-tests/codegen/rust-codegen-silent-var.t/run.t
@@ -1,0 +1,6 @@
+Rust codegen for role with silent recursion variable should report UnImplemented
+  $ nuscr --gencode-rust=A@SilentCounter SilentCounter.nuscr
+  nuscr: I'm sorry, it is unfortunate Rust codegen for silent recursion
+         variable 'counter' is not implemented (raised at
+         lib/codegen/rust/rustcodegen.ml: line 182)
+  [124]

--- a/test/cram-tests/codegen/rust-monitor-codegen.t/Adder.nuscr
+++ b/test/cram-tests/codegen/rust-monitor-codegen.t/Adder.nuscr
@@ -1,0 +1,13 @@
+protocol Adder(role C, role S) {
+  rec loop {
+    choice at C {
+      add(int) from C to S;
+      add(int) from C to S;
+      sum(int) from S to C;
+      continue loop;
+    } or {
+      bye() from C to S;
+      bye() from S to C;
+    }
+  }
+}

--- a/test/cram-tests/codegen/rust-monitor-codegen.t/run.t
+++ b/test/cram-tests/codegen/rust-monitor-codegen.t/run.t
@@ -46,7 +46,7 @@ Generate Rust monitor for Client
   impl AdderMonitor {
       pub fn new() -> Self {
           Self {
-              state: State::S0
+              state: State::S0,
           }
       }
   
@@ -126,7 +126,7 @@ Generate Rust monitor for Server
   impl AdderMonitor {
       pub fn new() -> Self {
           Self {
-              state: State::S0
+              state: State::S0,
           }
       }
   

--- a/test/cram-tests/codegen/rust-monitor-codegen.t/run.t
+++ b/test/cram-tests/codegen/rust-monitor-codegen.t/run.t
@@ -23,10 +23,19 @@ Generate Rust monitor for Client
       Recv,
   }
   
-  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub enum Value {
+      Int(i64),
+      Bool(bool),
+      String(String),
+      Unit,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
   pub struct Action {
       dir: Direction,
       label: Label,
+      payloads: Vec<Value>,
   }
   
   #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,11 +52,26 @@ Generate Rust monitor for Client
   
       pub fn step(&mut self, action: &Action) -> bool {
           match (self.state, action.dir, action.label) {
-              (State::S0, Direction::Send, Label::Add) => { self.state = State::S3; true }
-              (State::S0, Direction::Send, Label::Bye) => { self.state = State::S6; true }
-              (State::S3, Direction::Send, Label::Add) => { self.state = State::S4; true }
-              (State::S4, Direction::Recv, Label::Sum) => { self.state = State::S0; true }
-              (State::S6, Direction::Recv, Label::Bye) => { self.state = State::S7; true }
+              (State::S0, Direction::Send, Label::Add) => match action.payloads.as_slice() {
+                  [Value::Int(_)] => { self.state = State::S3; true }
+                  _ => false
+              },
+              (State::S0, Direction::Send, Label::Bye) => match action.payloads.as_slice() {
+                  [] => { self.state = State::S6; true }
+                  _ => false
+              },
+              (State::S3, Direction::Send, Label::Add) => match action.payloads.as_slice() {
+                  [Value::Int(_)] => { self.state = State::S4; true }
+                  _ => false
+              },
+              (State::S4, Direction::Recv, Label::Sum) => match action.payloads.as_slice() {
+                  [Value::Int(_)] => { self.state = State::S0; true }
+                  _ => false
+              },
+              (State::S6, Direction::Recv, Label::Bye) => match action.payloads.as_slice() {
+                  [] => { self.state = State::S7; true }
+                  _ => false
+              },
               _ => false
             }
       }
@@ -79,10 +103,19 @@ Generate Rust monitor for Server
       Recv,
   }
   
-  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub enum Value {
+      Int(i64),
+      Bool(bool),
+      String(String),
+      Unit,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
   pub struct Action {
       dir: Direction,
       label: Label,
+      payloads: Vec<Value>,
   }
   
   #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,11 +132,26 @@ Generate Rust monitor for Server
   
       pub fn step(&mut self, action: &Action) -> bool {
           match (self.state, action.dir, action.label) {
-              (State::S0, Direction::Recv, Label::Add) => { self.state = State::S3; true }
-              (State::S0, Direction::Recv, Label::Bye) => { self.state = State::S6; true }
-              (State::S3, Direction::Recv, Label::Add) => { self.state = State::S4; true }
-              (State::S4, Direction::Send, Label::Sum) => { self.state = State::S0; true }
-              (State::S6, Direction::Send, Label::Bye) => { self.state = State::S7; true }
+              (State::S0, Direction::Recv, Label::Add) => match action.payloads.as_slice() {
+                  [Value::Int(_)] => { self.state = State::S3; true }
+                  _ => false
+              },
+              (State::S0, Direction::Recv, Label::Bye) => match action.payloads.as_slice() {
+                  [] => { self.state = State::S6; true }
+                  _ => false
+              },
+              (State::S3, Direction::Recv, Label::Add) => match action.payloads.as_slice() {
+                  [Value::Int(_)] => { self.state = State::S4; true }
+                  _ => false
+              },
+              (State::S4, Direction::Send, Label::Sum) => match action.payloads.as_slice() {
+                  [Value::Int(_)] => { self.state = State::S0; true }
+                  _ => false
+              },
+              (State::S6, Direction::Send, Label::Bye) => match action.payloads.as_slice() {
+                  [] => { self.state = State::S7; true }
+                  _ => false
+              },
               _ => false
             }
       }

--- a/test/cram-tests/codegen/rust-monitor-codegen.t/run.t
+++ b/test/cram-tests/codegen/rust-monitor-codegen.t/run.t
@@ -1,7 +1,7 @@
 Generate Rust monitor for Client
   $ nuscr --gencode-rust=C@Adder Adder.nuscr > C_monitor.rs
   $ cat C_monitor.rs
-  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  #[derive(Debug, Clone, PartialEq, Eq)]
   enum State {
       S0,
       S3,
@@ -45,35 +45,53 @@ Generate Rust monitor for Client
   
   impl AdderMonitor {
       pub fn new() -> Self {
-          Self {
-              state: State::S0,
-          }
+          Self { state: State::S0 }
       }
   
       pub fn step(&mut self, action: &Action) -> bool {
-          match (self.state, action.dir, action.label) {
-              (State::S0, Direction::Send, Label::Add) => match action.payloads.as_slice() {
-                  [Value::Int(_)] => { self.state = State::S3; true }
-                  _ => false
-              },
-              (State::S0, Direction::Send, Label::Bye) => match action.payloads.as_slice() {
-                  [] => { self.state = State::S6; true }
-                  _ => false
-              },
-              (State::S3, Direction::Send, Label::Add) => match action.payloads.as_slice() {
-                  [Value::Int(_)] => { self.state = State::S4; true }
-                  _ => false
-              },
-              (State::S4, Direction::Recv, Label::Sum) => match action.payloads.as_slice() {
-                  [Value::Int(_)] => { self.state = State::S0; true }
-                  _ => false
-              },
-              (State::S6, Direction::Recv, Label::Bye) => match action.payloads.as_slice() {
-                  [] => { self.state = State::S7; true }
-                  _ => false
-              },
+          match (self.state.clone(), &action.dir, &action.label) {
+              (State::S0, Direction::Send, Label::Add) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(_)] => {
+                          self.state = State::S3;
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S0, Direction::Send, Label::Bye) =>
+                  match action.payloads.as_slice() {
+                      [] => {
+                          self.state = State::S6;
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S3, Direction::Send, Label::Add) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(_)] => {
+                          self.state = State::S4;
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S4, Direction::Recv, Label::Sum) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(_)] => {
+                          self.state = State::S0;
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S6, Direction::Recv, Label::Bye) =>
+                  match action.payloads.as_slice() {
+                      [] => {
+                          self.state = State::S7;
+                          true
+                      }
+                      _ => false
+                  },
               _ => false
-            }
+          }
       }
   }
   
@@ -81,7 +99,7 @@ Generate Rust monitor for Client
 Generate Rust monitor for Server
   $ nuscr --gencode-rust=S@Adder Adder.nuscr > S_monitor.rs
   $ cat S_monitor.rs
-  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  #[derive(Debug, Clone, PartialEq, Eq)]
   enum State {
       S0,
       S3,
@@ -125,35 +143,53 @@ Generate Rust monitor for Server
   
   impl AdderMonitor {
       pub fn new() -> Self {
-          Self {
-              state: State::S0,
-          }
+          Self { state: State::S0 }
       }
   
       pub fn step(&mut self, action: &Action) -> bool {
-          match (self.state, action.dir, action.label) {
-              (State::S0, Direction::Recv, Label::Add) => match action.payloads.as_slice() {
-                  [Value::Int(_)] => { self.state = State::S3; true }
-                  _ => false
-              },
-              (State::S0, Direction::Recv, Label::Bye) => match action.payloads.as_slice() {
-                  [] => { self.state = State::S6; true }
-                  _ => false
-              },
-              (State::S3, Direction::Recv, Label::Add) => match action.payloads.as_slice() {
-                  [Value::Int(_)] => { self.state = State::S4; true }
-                  _ => false
-              },
-              (State::S4, Direction::Send, Label::Sum) => match action.payloads.as_slice() {
-                  [Value::Int(_)] => { self.state = State::S0; true }
-                  _ => false
-              },
-              (State::S6, Direction::Send, Label::Bye) => match action.payloads.as_slice() {
-                  [] => { self.state = State::S7; true }
-                  _ => false
-              },
+          match (self.state.clone(), &action.dir, &action.label) {
+              (State::S0, Direction::Recv, Label::Add) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(_)] => {
+                          self.state = State::S3;
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S0, Direction::Recv, Label::Bye) =>
+                  match action.payloads.as_slice() {
+                      [] => {
+                          self.state = State::S6;
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S3, Direction::Recv, Label::Add) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(_)] => {
+                          self.state = State::S4;
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S4, Direction::Send, Label::Sum) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(_)] => {
+                          self.state = State::S0;
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S6, Direction::Send, Label::Bye) =>
+                  match action.payloads.as_slice() {
+                      [] => {
+                          self.state = State::S7;
+                          true
+                      }
+                      _ => false
+                  },
               _ => false
-            }
+          }
       }
   }
   

--- a/test/cram-tests/codegen/rust-monitor-codegen.t/run.t
+++ b/test/cram-tests/codegen/rust-monitor-codegen.t/run.t
@@ -1,0 +1,117 @@
+Generate Rust monitor for Client
+  $ nuscr --gencode-rust=C@Adder Adder.nuscr > C_monitor.rs
+  $ cat C_monitor.rs
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  enum State {
+      S0,
+      S3,
+      S4,
+      S6,
+      S7,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum Label {
+      Add,
+      Bye,
+      Sum,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum Direction {
+      Send,
+      Recv,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub struct Action {
+      dir: Direction,
+      label: Label,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct AdderMonitor {
+      state: State,
+  }
+  
+  impl AdderMonitor {
+      pub fn new() -> Self {
+          Self {
+              state: State::S0
+          }
+      }
+  
+      pub fn step(&mut self, action: &Action) -> bool {
+          match (self.state, action.dir, action.label) {
+              (State::S0, Direction::Send, Label::Add) => { self.state = State::S3; true }
+              (State::S0, Direction::Send, Label::Bye) => { self.state = State::S6; true }
+              (State::S3, Direction::Send, Label::Add) => { self.state = State::S4; true }
+              (State::S4, Direction::Recv, Label::Sum) => { self.state = State::S0; true }
+              (State::S6, Direction::Recv, Label::Bye) => { self.state = State::S7; true }
+              _ => false
+            }
+      }
+  }
+  
+
+Generate Rust monitor for Server
+  $ nuscr --gencode-rust=S@Adder Adder.nuscr > S_monitor.rs
+  $ cat S_monitor.rs
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  enum State {
+      S0,
+      S3,
+      S4,
+      S6,
+      S7,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum Label {
+      Add,
+      Bye,
+      Sum,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum Direction {
+      Send,
+      Recv,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub struct Action {
+      dir: Direction,
+      label: Label,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct AdderMonitor {
+      state: State,
+  }
+  
+  impl AdderMonitor {
+      pub fn new() -> Self {
+          Self {
+              state: State::S0
+          }
+      }
+  
+      pub fn step(&mut self, action: &Action) -> bool {
+          match (self.state, action.dir, action.label) {
+              (State::S0, Direction::Recv, Label::Add) => { self.state = State::S3; true }
+              (State::S0, Direction::Recv, Label::Bye) => { self.state = State::S6; true }
+              (State::S3, Direction::Recv, Label::Add) => { self.state = State::S4; true }
+              (State::S4, Direction::Send, Label::Sum) => { self.state = State::S0; true }
+              (State::S6, Direction::Send, Label::Bye) => { self.state = State::S7; true }
+              _ => false
+            }
+      }
+  }
+  
+
+Compile Client monitor
+  $ rustc --edition 2021 --crate-type lib C_monitor.rs -o C_monitor.rlib
+
+Compile Server monitor
+  $ rustc --edition 2021 --crate-type lib S_monitor.rs -o S_monitor.rlib

--- a/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/RunningSum.nuscr
+++ b/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/RunningSum.nuscr
@@ -1,0 +1,14 @@
+(*# RefinementTypes #*)
+
+global protocol RunningSum(role C, role S) {
+  rec loop [total<C, S>: (total: int{total < 100}) = 0] {
+    choice at C {
+      add(x: int{x > 0}, y: int{y > 0}) from C to S;
+      sum(r: int{r = x + y}) from S to C;
+      continue loop [total + r];
+    } or {
+      bye() from C to S;
+      bye() from S to C;
+    }
+  }
+}

--- a/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/run.t
+++ b/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/run.t
@@ -1,0 +1,199 @@
+Generate Rust monitor for Client
+  $ nuscr --gencode-rust=C@RunningSum RunningSum.nuscr > C_monitor.rs
+  $ cat C_monitor.rs
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  enum State {
+      S0,
+      S3,
+      S5,
+      S6,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum Label {
+      Add,
+      Bye,
+      Sum,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum Direction {
+      Send,
+      Recv,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub enum Value {
+      Int(i64),
+      Bool(bool),
+      String(String),
+      Unit,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct Action {
+      dir: Direction,
+      label: Label,
+      payloads: Vec<Value>,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct RunningsumMonitor {
+      state: State,
+  }
+  
+  impl RunningsumMonitor {
+      pub fn new() -> Self {
+          Self {
+              state: State::S0
+          }
+      }
+  
+      pub fn step(&mut self, action: &Action) -> bool {
+          match (self.state, action.dir, action.label) {
+              (State::S0, Direction::Send, Label::Add) => match action.payloads.as_slice() {
+                  [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+                  _ => false
+              },
+              (State::S0, Direction::Send, Label::Bye) => match action.payloads.as_slice() {
+                  [] => { self.state = State::S5; true }
+                  _ => false
+              },
+              (State::S3, Direction::Recv, Label::Sum) => match action.payloads.as_slice() {
+                  [Value::Int(r)] => { self.state = State::S0; true }
+                  _ => false
+              },
+              (State::S5, Direction::Recv, Label::Bye) => match action.payloads.as_slice() {
+                  [] => { self.state = State::S6; true }
+                  _ => false
+              },
+              _ => false
+            }
+      }
+  }
+  
+
+Generate Rust monitor for Server
+  $ nuscr --gencode-rust=S@RunningSum RunningSum.nuscr > S_monitor.rs
+  $ cat S_monitor.rs
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  enum State {
+      S0,
+      S3,
+      S5,
+      S6,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum Label {
+      Add,
+      Bye,
+      Sum,
+  }
+  
+  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  pub enum Direction {
+      Send,
+      Recv,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub enum Value {
+      Int(i64),
+      Bool(bool),
+      String(String),
+      Unit,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct Action {
+      dir: Direction,
+      label: Label,
+      payloads: Vec<Value>,
+  }
+  
+  #[derive(Debug, Clone, PartialEq, Eq)]
+  pub struct RunningsumMonitor {
+      state: State,
+  }
+  
+  impl RunningsumMonitor {
+      pub fn new() -> Self {
+          Self {
+              state: State::S0
+          }
+      }
+  
+      pub fn step(&mut self, action: &Action) -> bool {
+          match (self.state, action.dir, action.label) {
+              (State::S0, Direction::Recv, Label::Add) => match action.payloads.as_slice() {
+                  [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+                  _ => false
+              },
+              (State::S0, Direction::Recv, Label::Bye) => match action.payloads.as_slice() {
+                  [] => { self.state = State::S5; true }
+                  _ => false
+              },
+              (State::S3, Direction::Send, Label::Sum) => match action.payloads.as_slice() {
+                  [Value::Int(r)] => { self.state = State::S0; true }
+                  _ => false
+              },
+              (State::S5, Direction::Send, Label::Bye) => match action.payloads.as_slice() {
+                  [] => { self.state = State::S6; true }
+                  _ => false
+              },
+              _ => false
+            }
+      }
+  }
+  
+
+Compile Client monitor
+  $ rustc --edition 2021 --crate-type lib C_monitor.rs -o C_monitor.rlib
+  warning: unused variable: `x`
+    --> C_monitor.rs:52:29
+     |
+  52 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+     |                             ^ help: if this is intentional, prefix it with an underscore: `_x`
+     |
+     = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+  
+  warning: unused variable: `y`
+    --> C_monitor.rs:52:44
+     |
+  52 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+     |                                            ^ help: if this is intentional, prefix it with an underscore: `_y`
+  
+  warning: unused variable: `r`
+    --> C_monitor.rs:60:29
+     |
+  60 |                 [Value::Int(r)] => { self.state = State::S0; true }
+     |                             ^ help: if this is intentional, prefix it with an underscore: `_r`
+  
+  warning: 3 warnings emitted
+  
+
+Compile Server monitor
+  $ rustc --edition 2021 --crate-type lib S_monitor.rs -o S_monitor.rlib
+  warning: unused variable: `x`
+    --> S_monitor.rs:52:29
+     |
+  52 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+     |                             ^ help: if this is intentional, prefix it with an underscore: `_x`
+     |
+     = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+  
+  warning: unused variable: `y`
+    --> S_monitor.rs:52:44
+     |
+  52 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+     |                                            ^ help: if this is intentional, prefix it with an underscore: `_y`
+  
+  warning: unused variable: `r`
+    --> S_monitor.rs:60:29
+     |
+  60 |                 [Value::Int(r)] => { self.state = State::S0; true }
+     |                             ^ help: if this is intentional, prefix it with an underscore: `_r`
+  
+  warning: 3 warnings emitted
+  

--- a/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/run.t
+++ b/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/run.t
@@ -1,12 +1,12 @@
 Generate Rust monitor for Client
   $ nuscr --gencode-rust=C@RunningSum RunningSum.nuscr > C_monitor.rs
   $ cat C_monitor.rs
-  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  #[derive(Debug, Clone, PartialEq, Eq)]
   enum State {
-      S0,
-      S3,
-      S5,
-      S6,
+      S0 { total: i64 },
+      S3 { total: i64, x: i64, y: i64 },
+      S5 { total: i64 },
+      S6 { total: i64 },
   }
   
   #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,37 +40,56 @@ Generate Rust monitor for Client
   #[derive(Debug, Clone, PartialEq, Eq)]
   pub struct RunningsumMonitor {
       state: State,
-      total: i64,
   }
   
   impl RunningsumMonitor {
       pub fn new() -> Self {
-          Self {
-              state: State::S0,
-              total: 0,
-          }
+          Self { state: State::S0 { total: 0 } }
       }
   
       pub fn step(&mut self, action: &Action) -> bool {
-          match (self.state, action.dir, action.label) {
-              (State::S0, Direction::Send, Label::Add) => match action.payloads.as_slice() {
-                  [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
-                  _ => false
-              },
-              (State::S0, Direction::Send, Label::Bye) => match action.payloads.as_slice() {
-                  [] => { self.state = State::S5; true }
-                  _ => false
-              },
-              (State::S3, Direction::Recv, Label::Sum) => match action.payloads.as_slice() {
-                  [Value::Int(r)] => { self.state = State::S0; true }
-                  _ => false
-              },
-              (State::S5, Direction::Recv, Label::Bye) => match action.payloads.as_slice() {
-                  [] => { self.state = State::S6; true }
-                  _ => false
-              },
+          match (self.state.clone(), &action.dir, &action.label) {
+              (State::S0 { total }, Direction::Send, Label::Add) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(x), Value::Int(y)] => {
+                          let x = x.clone();
+                          let y = y.clone();
+                          if !((x) > (0) && (y) > (0)) { return false; }
+                          self.state = State::S3 { total, x, y };
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S0 { total }, Direction::Send, Label::Bye) =>
+                  match action.payloads.as_slice() {
+                      [] => {
+                          self.state = State::S5 { total };
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S3 { total, x, y }, Direction::Recv, Label::Sum) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(r)] => {
+                          let r = r.clone();
+                          if !((r) == ((x) + (y))) { return false; }
+                          let new_total = (total) + (r);
+                          if !((new_total) < (100)) { return false; }
+                          self.state = State::S0 { total: new_total };
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S5 { total }, Direction::Recv, Label::Bye) =>
+                  match action.payloads.as_slice() {
+                      [] => {
+                          self.state = State::S6 { total };
+                          true
+                      }
+                      _ => false
+                  },
               _ => false
-            }
+          }
       }
   }
   
@@ -78,12 +97,12 @@ Generate Rust monitor for Client
 Generate Rust monitor for Server
   $ nuscr --gencode-rust=S@RunningSum RunningSum.nuscr > S_monitor.rs
   $ cat S_monitor.rs
-  #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+  #[derive(Debug, Clone, PartialEq, Eq)]
   enum State {
-      S0,
-      S3,
-      S5,
-      S6,
+      S0 { total: i64 },
+      S3 { total: i64, x: i64, y: i64 },
+      S5 { total: i64 },
+      S6 { total: i64 },
   }
   
   #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -117,87 +136,62 @@ Generate Rust monitor for Server
   #[derive(Debug, Clone, PartialEq, Eq)]
   pub struct RunningsumMonitor {
       state: State,
-      total: i64,
   }
   
   impl RunningsumMonitor {
       pub fn new() -> Self {
-          Self {
-              state: State::S0,
-              total: 0,
-          }
+          Self { state: State::S0 { total: 0 } }
       }
   
       pub fn step(&mut self, action: &Action) -> bool {
-          match (self.state, action.dir, action.label) {
-              (State::S0, Direction::Recv, Label::Add) => match action.payloads.as_slice() {
-                  [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
-                  _ => false
-              },
-              (State::S0, Direction::Recv, Label::Bye) => match action.payloads.as_slice() {
-                  [] => { self.state = State::S5; true }
-                  _ => false
-              },
-              (State::S3, Direction::Send, Label::Sum) => match action.payloads.as_slice() {
-                  [Value::Int(r)] => { self.state = State::S0; true }
-                  _ => false
-              },
-              (State::S5, Direction::Send, Label::Bye) => match action.payloads.as_slice() {
-                  [] => { self.state = State::S6; true }
-                  _ => false
-              },
+          match (self.state.clone(), &action.dir, &action.label) {
+              (State::S0 { total }, Direction::Recv, Label::Add) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(x), Value::Int(y)] => {
+                          let x = x.clone();
+                          let y = y.clone();
+                          if !((x) > (0) && (y) > (0)) { return false; }
+                          self.state = State::S3 { total, x, y };
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S0 { total }, Direction::Recv, Label::Bye) =>
+                  match action.payloads.as_slice() {
+                      [] => {
+                          self.state = State::S5 { total };
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S3 { total, x, y }, Direction::Send, Label::Sum) =>
+                  match action.payloads.as_slice() {
+                      [Value::Int(r)] => {
+                          let r = r.clone();
+                          if !((r) == ((x) + (y))) { return false; }
+                          let new_total = (total) + (r);
+                          if !((new_total) < (100)) { return false; }
+                          self.state = State::S0 { total: new_total };
+                          true
+                      }
+                      _ => false
+                  },
+              (State::S5 { total }, Direction::Send, Label::Bye) =>
+                  match action.payloads.as_slice() {
+                      [] => {
+                          self.state = State::S6 { total };
+                          true
+                      }
+                      _ => false
+                  },
               _ => false
-            }
+          }
       }
   }
   
 
 Compile Client monitor
   $ rustc --edition 2021 --crate-type lib C_monitor.rs -o C_monitor.rlib
-  warning: unused variable: `x`
-    --> C_monitor.rs:54:29
-     |
-  54 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
-     |                             ^ help: if this is intentional, prefix it with an underscore: `_x`
-     |
-     = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
-  
-  warning: unused variable: `y`
-    --> C_monitor.rs:54:44
-     |
-  54 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
-     |                                            ^ help: if this is intentional, prefix it with an underscore: `_y`
-  
-  warning: unused variable: `r`
-    --> C_monitor.rs:62:29
-     |
-  62 |                 [Value::Int(r)] => { self.state = State::S0; true }
-     |                             ^ help: if this is intentional, prefix it with an underscore: `_r`
-  
-  warning: 3 warnings emitted
-  
 
 Compile Server monitor
   $ rustc --edition 2021 --crate-type lib S_monitor.rs -o S_monitor.rlib
-  warning: unused variable: `x`
-    --> S_monitor.rs:54:29
-     |
-  54 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
-     |                             ^ help: if this is intentional, prefix it with an underscore: `_x`
-     |
-     = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
-  
-  warning: unused variable: `y`
-    --> S_monitor.rs:54:44
-     |
-  54 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
-     |                                            ^ help: if this is intentional, prefix it with an underscore: `_y`
-  
-  warning: unused variable: `r`
-    --> S_monitor.rs:62:29
-     |
-  62 |                 [Value::Int(r)] => { self.state = State::S0; true }
-     |                             ^ help: if this is intentional, prefix it with an underscore: `_r`
-  
-  warning: 3 warnings emitted
-  

--- a/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/run.t
+++ b/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/run.t
@@ -40,12 +40,14 @@ Generate Rust monitor for Client
   #[derive(Debug, Clone, PartialEq, Eq)]
   pub struct RunningsumMonitor {
       state: State,
+      total: i64,
   }
   
   impl RunningsumMonitor {
       pub fn new() -> Self {
           Self {
-              state: State::S0
+              state: State::S0,
+              total: 0,
           }
       }
   
@@ -115,12 +117,14 @@ Generate Rust monitor for Server
   #[derive(Debug, Clone, PartialEq, Eq)]
   pub struct RunningsumMonitor {
       state: State,
+      total: i64,
   }
   
   impl RunningsumMonitor {
       pub fn new() -> Self {
           Self {
-              state: State::S0
+              state: State::S0,
+              total: 0,
           }
       }
   
@@ -151,23 +155,23 @@ Generate Rust monitor for Server
 Compile Client monitor
   $ rustc --edition 2021 --crate-type lib C_monitor.rs -o C_monitor.rlib
   warning: unused variable: `x`
-    --> C_monitor.rs:52:29
+    --> C_monitor.rs:54:29
      |
-  52 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+  54 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
      |                             ^ help: if this is intentional, prefix it with an underscore: `_x`
      |
      = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
   
   warning: unused variable: `y`
-    --> C_monitor.rs:52:44
+    --> C_monitor.rs:54:44
      |
-  52 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+  54 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
      |                                            ^ help: if this is intentional, prefix it with an underscore: `_y`
   
   warning: unused variable: `r`
-    --> C_monitor.rs:60:29
+    --> C_monitor.rs:62:29
      |
-  60 |                 [Value::Int(r)] => { self.state = State::S0; true }
+  62 |                 [Value::Int(r)] => { self.state = State::S0; true }
      |                             ^ help: if this is intentional, prefix it with an underscore: `_r`
   
   warning: 3 warnings emitted
@@ -176,23 +180,23 @@ Compile Client monitor
 Compile Server monitor
   $ rustc --edition 2021 --crate-type lib S_monitor.rs -o S_monitor.rlib
   warning: unused variable: `x`
-    --> S_monitor.rs:52:29
+    --> S_monitor.rs:54:29
      |
-  52 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+  54 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
      |                             ^ help: if this is intentional, prefix it with an underscore: `_x`
      |
      = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
   
   warning: unused variable: `y`
-    --> S_monitor.rs:52:44
+    --> S_monitor.rs:54:44
      |
-  52 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
+  54 |                 [Value::Int(x), Value::Int(y)] => { self.state = State::S3; true }
      |                                            ^ help: if this is intentional, prefix it with an underscore: `_y`
   
   warning: unused variable: `r`
-    --> S_monitor.rs:60:29
+    --> S_monitor.rs:62:29
      |
-  60 |                 [Value::Int(r)] => { self.state = State::S0; true }
+  62 |                 [Value::Int(r)] => { self.state = State::S0; true }
      |                             ^ help: if this is intentional, prefix it with an underscore: `_r`
   
   warning: 3 warnings emitted

--- a/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/run.t
+++ b/test/cram-tests/codegen/rust-monitor-refinement-codegen.t/run.t
@@ -38,11 +38,11 @@ Generate Rust monitor for Client
   }
   
   #[derive(Debug, Clone, PartialEq, Eq)]
-  pub struct RunningsumMonitor {
+  pub struct RunningSumMonitor {
       state: State,
   }
   
-  impl RunningsumMonitor {
+  impl RunningSumMonitor {
       pub fn new() -> Self {
           Self { state: State::S0 { total: 0 } }
       }
@@ -134,11 +134,11 @@ Generate Rust monitor for Server
   }
   
   #[derive(Debug, Clone, PartialEq, Eq)]
-  pub struct RunningsumMonitor {
+  pub struct RunningSumMonitor {
       state: State,
   }
   
-  impl RunningsumMonitor {
+  impl RunningSumMonitor {
       pub fn new() -> Self {
           Self { state: State::S0 { total: 0 } }
       }

--- a/test/cram-tests/core/ambiguous-choice.t/run.t
+++ b/test/cram-tests/core/ambiguous-choice.t/run.t
@@ -1,5 +1,4 @@
 The first message in choices must uniquely identify the branch.
   $ nuscr --project A@Ambiguous Ambiguous.nuscr
-  nuscr: User error: Duplicate label m in choices at 5:5 to 5:6 in:
-         Ambiguous.nuscr
+  nuscr: User error: Duplicate label m in choices at 5:5 to 5:6 in: Ambiguous.nuscr
   [124]

--- a/test/cram-tests/core/reflexive-message.t/run.t
+++ b/test/cram-tests/core/reflexive-message.t/run.t
@@ -1,5 +1,4 @@
 Reflexive messages (e.g. from A to A) are not permitted.
   $ nuscr --project A@Reflexive ReflexiveMessage.nuscr
-  nuscr: User error: Reflexive message of role A at 2:12 to 2:18 in:
-         ReflexiveMessage.nuscr
+  nuscr: User error: Reflexive message of role A at 2:12 to 2:18 in: ReflexiveMessage.nuscr
   [124]

--- a/test/cram-tests/core/unbound-recursion-name.t/run.t
+++ b/test/cram-tests/core/unbound-recursion-name.t/run.t
@@ -1,5 +1,4 @@
 Unbound recursion names in `continue` is not allowed.
   $ nuscr --project A@P UnboundRec.nuscr
-  nuscr: User error: Unbound name Z in `continue` at 5:16 to 5:17 in:
-         UnboundRec.nuscr
+  nuscr: User error: Unbound name Z in `continue` at 5:16 to 5:17 in: UnboundRec.nuscr
   [124]

--- a/test/cram-tests/core/unguarded-recursion.t/run.t
+++ b/test/cram-tests/core/unguarded-recursion.t/run.t
@@ -1,18 +1,15 @@
 Unguarded recursion in global protocol should raise an error.
 
   $ nuscr --show-global-type Unguarded UnguardedSimple.nuscr
-  nuscr: User error: Unguarded type variable X at 3:14 to 3:15 in:
-         UnguardedSimple.nuscr
+  nuscr: User error: Unguarded type variable X at 3:14 to 3:15 in: UnguardedSimple.nuscr
   [124]
 
   $ nuscr --show-global-type Unguarded UnguardedDo.nuscr
-  nuscr: User error: Unguarded type variable __Unguarded_A_B at 2:3 to 2:22 in:
-         UnguardedDo.nuscr
+  nuscr: User error: Unguarded type variable __Unguarded_A_B at 2:3 to 2:22 in: UnguardedDo.nuscr
   [124]
 
 
 Although we can remove the unguarded recursion and the protocol still makes some sense, we will still report this error.
   $ nuscr --show-global-type Unguarded UnguardedChoice.nuscr
-  nuscr: User error: Unguarded type variable X at 4:16 to 4:17 in:
-         UnguardedChoice.nuscr
+  nuscr: User error: Unguarded type variable X at 4:16 to 4:17 in: UnguardedChoice.nuscr
   [124]

--- a/test/cram-tests/core/unmergable-choice.t/run.t
+++ b/test/cram-tests/core/unmergable-choice.t/run.t
@@ -1,5 +1,8 @@
 Should report an issue because of unmergeable local type when projecting on C
   $ nuscr --project C@Bad Bad.nuscr
-  nuscr: User error: Unable to merge: (end) and m3() from A; (end) when
-         projecting on role C
+  nuscr: User error: Unable to merge: (end)
+         and
+         m3() from A;
+         (end)
+         when projecting on role C
   [124]

--- a/test/cram-tests/refinements/merge-silent-recv.t/run.t
+++ b/test/cram-tests/refinements/merge-silent-recv.t/run.t
@@ -2,23 +2,40 @@ C gets confused by the Confuse protocol, since they cannot determine whether A
 takes Foo branch or Bar branch.
 
   $ nuscr --project C@Confuse Confuse.nuscr
-  nuscr: User error: Unable to merge: (silent) x(int); One(xx: int) from A;
-         (end) and (silent) y(int); One(xx: int) from A; (end) when projecting
-         on role C
+  nuscr: User error: Unable to merge: (silent) x(int);
+         One(xx: int) from A;
+         (end)
+         and
+         (silent) y(int);
+         One(xx: int) from A;
+         (end)
+         when projecting on role C
   [124]
 
   $ nuscr --project C@Confuse AlsoConfuse.nuscr
-  nuscr: User error: Unable to merge: (silent) x(int); (silent) xxx(int);
-         One(xx: int) from A; (end) and (silent) y(int); One(xx: int) from A;
-         (end) when projecting on role C
+  nuscr: User error: Unable to merge: (silent) x(int);
+         (silent) xxx(int);
+         One(xx: int) from A;
+         (end)
+         and
+         (silent) y(int);
+         One(xx: int) from A;
+         (end)
+         when projecting on role C
   [124]
 
 C cannot receive from either A or B, so they get very confused.
 
   $ nuscr --project C@Confuse VeryConfuse.nuscr
-  nuscr: User error: Unable to merge: (silent) x(int); (silent) xxx(int);
-         One(xx: int) from B; (end) and (silent) y(int); One(xx: int) from A;
-         (end) when projecting on role C
+  nuscr: User error: Unable to merge: (silent) x(int);
+         (silent) xxx(int);
+         One(xx: int) from B;
+         (end)
+         and
+         (silent) y(int);
+         One(xx: int) from A;
+         (end)
+         when projecting on role C
   [124]
 
 C doesn't get confused when they can be made aware of A's choice (directly).

--- a/test/cram-tests/refinements/merge-silent-send.t/run.t
+++ b/test/cram-tests/refinements/merge-silent-send.t/run.t
@@ -2,6 +2,12 @@ MergeSend should fail, since C cannot tell how One or Two was used.
 (At least in the current theory, maybe later we can try to do some weakening of
 conditions)
   $ nuscr --project C@MergeSend Merge.nuscr
-  nuscr: User error: Unable to merge: (silent) x(int); Stuff() to B; (end) and
-         (silent) y(int); Stuff() to B; (end) when projecting on role C
+  nuscr: User error: Unable to merge: (silent) x(int);
+         Stuff() to B;
+         (end)
+         and
+         (silent) y(int);
+         Stuff() to B;
+         (end)
+         when projecting on role C
   [124]

--- a/test/cram-tests/refinements/strlen.t/run.t
+++ b/test/cram-tests/refinements/strlen.t/run.t
@@ -44,6 +44,5 @@ PasswordManager2 has a too short initial password, and an error is expected.
   (assert (= freshvar$0 stored_pass))
   (check-sat)
   
-  nuscr: User error: Type Error: Expression "pass" should be of type
-         (stored_pass:string{len(stored_pass) >= 6})
+  nuscr: User error: Type Error: Expression "pass" should be of type (stored_pass:string{len(stored_pass) >= 6})
   [124]

--- a/test/cram-tests/refinements/unable-to-merge-rec-vars-in-fsm.t/run.t
+++ b/test/cram-tests/refinements/unable-to-merge-rec-vars-in-fsm.t/run.t
@@ -1,5 +1,4 @@
 Currently it is not possible to mix two recursion variables in a choice.
   $ nuscr --fsm A@Unable Unable.nuscr
-  nuscr: I'm sorry, it is unfortunate Multiple recursions with variables in
-         choices is not implemented (raised at lib/mpst/efsm.ml: line 332)
+  nuscr: I'm sorry, it is unfortunate Multiple recursions with variables in choices is not implemented (raised at lib/mpst/efsm.ml: line 332)
   [124]


### PR DESCRIPTION
Only works in the binary case, mainly due to non-supported silent variables

Still needs more cram-tests for refinement edgecases + unit tests for compute_var_map

Could use more validation, like in the Go codegen. Maybe reuse this?