### PR TITLE
add extra brackets around constraints

### DIFF
--- a/lib/codegen/rust/rustexpr.ml
+++ b/lib/codegen/rust/rustexpr.ml
@@ -129,4 +129,10 @@ let rust_payload_constraints payloads =
           Some (rust_show_expr pred)
       | _ -> None )
   in
-  match preds with [] -> None | _ -> Some (String.concat ~sep:" && " preds)
+  match preds with
+  | [] -> None
+  | [single] -> Some single
+  | _ ->
+      Some
+        (String.concat ~sep:" && "
+           (List.map preds ~f:(fun p -> "(" ^ p ^ ")")) )

--- a/test/cram-tests/codegen/rust-refinement-codegen.t/run.t
+++ b/test/cram-tests/codegen/rust-refinement-codegen.t/run.t
@@ -76,7 +76,7 @@ Generate Rust monitor for Client
                   let total = *total;
                   let x = *x;
                   let y = *y;
-                  if !((x) > (0) && (y) > (0)) { self.state = RunningSumState::Error; return Err(Violation::ConstraintFailed { expr: "(x) > (0) && (y) > (0)" }); }
+                  if !(((x) > (0)) && ((y) > (0))) { self.state = RunningSumState::Error; return Err(Violation::ConstraintFailed { expr: "((x) > (0)) && ((y) > (0))" }); }
                   self.state = RunningSumState::S3 { total, x, y };
                   Ok(())
               }
@@ -188,7 +188,7 @@ Generate Rust monitor for Server
                   let total = *total;
                   let x = *x;
                   let y = *y;
-                  if !((x) > (0) && (y) > (0)) { self.state = RunningSumState::Error; return Err(Violation::ConstraintFailed { expr: "(x) > (0) && (y) > (0)" }); }
+                  if !(((x) > (0)) && ((y) > (0))) { self.state = RunningSumState::Error; return Err(Violation::ConstraintFailed { expr: "((x) > (0)) && ((y) > (0))" }); }
                   self.state = RunningSumState::S3 { total, x, y };
                   Ok(())
               }
@@ -274,7 +274,7 @@ Production codegen (no support types, not compiled)
                   let total = *total;
                   let x = *x;
                   let y = *y;
-                  if !((x) > (0) && (y) > (0)) { self.state = RunningSumState::Error; return Err(Violation::ConstraintFailed { expr: "(x) > (0) && (y) > (0)" }); }
+                  if !(((x) > (0)) && ((y) > (0))) { self.state = RunningSumState::Error; return Err(Violation::ConstraintFailed { expr: "((x) > (0)) && ((y) > (0))" }); }
                   self.state = RunningSumState::S3 { total, x, y };
                   Ok(())
               }
@@ -353,7 +353,7 @@ Production codegen (no support types, not compiled)
                   let total = *total;
                   let x = *x;
                   let y = *y;
-                  if !((x) > (0) && (y) > (0)) { self.state = RunningSumState::Error; return Err(Violation::ConstraintFailed { expr: "(x) > (0) && (y) > (0)" }); }
+                  if !(((x) > (0)) && ((y) > (0))) { self.state = RunningSumState::Error; return Err(Violation::ConstraintFailed { expr: "((x) > (0)) && ((y) > (0))" }); }
                   self.state = RunningSumState::S3 { total, x, y };
                   Ok(())
               }

--- a/test/cram-tests/codegen/rust-refinement-multi-payload.t/run.t
+++ b/test/cram-tests/codegen/rust-refinement-multi-payload.t/run.t
@@ -67,7 +67,7 @@ Generate Rust monitor for Client (multi payload, cross-payload reference)
               (MultiPayloadState::S0, Action::Req { dir: Direction::Send, a, b, .. }) => {
                   let a = *a;
                   let b = *b;
-                  if !((a) > (0) && ((b) > (0)) && ((b) < (a))) { self.state = MultiPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "(a) > (0) && ((b) > (0)) && ((b) < (a))" }); }
+                  if !(((a) > (0)) && (((b) > (0)) && ((b) < (a)))) { self.state = MultiPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "((a) > (0)) && (((b) > (0)) && ((b) < (a)))" }); }
                   self.state = MultiPayloadState::S1 { a, b };
                   Ok(())
               }
@@ -154,7 +154,7 @@ Generate Rust monitor for Server (nested arith, cross-payload reference)
               (MultiPayloadState::S0, Action::Req { dir: Direction::Recv, a, b, .. }) => {
                   let a = *a;
                   let b = *b;
-                  if !((a) > (0) && ((b) > (0)) && ((b) < (a))) { self.state = MultiPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "(a) > (0) && ((b) > (0)) && ((b) < (a))" }); }
+                  if !(((a) > (0)) && (((b) > (0)) && ((b) < (a)))) { self.state = MultiPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "((a) > (0)) && (((b) > (0)) && ((b) < (a)))" }); }
                   self.state = MultiPayloadState::S1 { a, b };
                   Ok(())
               }
@@ -216,7 +216,7 @@ Production codegen (no support types, not compiled)
               (MultiPayloadState::S0, Action::Req { dir: Direction::Send, a, b, .. }) => {
                   let a = *a;
                   let b = *b;
-                  if !((a) > (0) && ((b) > (0)) && ((b) < (a))) { self.state = MultiPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "(a) > (0) && ((b) > (0)) && ((b) < (a))" }); }
+                  if !(((a) > (0)) && (((b) > (0)) && ((b) < (a)))) { self.state = MultiPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "((a) > (0)) && (((b) > (0)) && ((b) < (a)))" }); }
                   self.state = MultiPayloadState::S1 { a, b };
                   Ok(())
               }
@@ -271,7 +271,7 @@ Production codegen (no support types, not compiled)
               (MultiPayloadState::S0, Action::Req { dir: Direction::Recv, a, b, .. }) => {
                   let a = *a;
                   let b = *b;
-                  if !((a) > (0) && ((b) > (0)) && ((b) < (a))) { self.state = MultiPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "(a) > (0) && ((b) > (0)) && ((b) < (a))" }); }
+                  if !(((a) > (0)) && (((b) > (0)) && ((b) < (a)))) { self.state = MultiPayloadState::Error; return Err(Violation::ConstraintFailed { expr: "((a) > (0)) && (((b) > (0)) && ((b) < (a)))" }); }
                   self.state = MultiPayloadState::S1 { a, b };
                   Ok(())
               }


### PR DESCRIPTION
Right now a constraint like x:int{x >0 || x < 0} leaks its disjunction when multiple constraints are conjoined. To fix this, I add brackets around each constraint when multiple are present